### PR TITLE
fields using key "heading" being dropped

### DIFF
--- a/lib/list.js
+++ b/lib/list.js
@@ -220,7 +220,7 @@ List.prototype.add = function() {
 				});
 			}
 		} else {
-			if (def.heading) 
+			if (def.heading && 'string' == typeof def.heading) 
 				this.uiElements.push({
 					type: 'heading',
 					heading: def.heading,


### PR DESCRIPTION
checking that its being passed a string. 
If its passed an object, it should be treated like a field and not a heading.
