### PR TITLE
Fix a error produced when create entity without enter a location field type

### DIFF
--- a/lib/fieldTypes/location.js
+++ b/lib/fieldTypes/location.js
@@ -233,14 +233,14 @@ location.prototype.updateItem = function(item, data) {
 	
 	if (paths.geo in data) {
 	
-		var oldGeo = item.get(paths.geo),
+		var oldGeo = item.get(paths.geo) || [],
 			newGeo = data[paths.geo];
 		
 		if (!Array.isArray(newGeo) || newGeo.length != 2) {
 			newGeo = [];
 		}
 		
-		if (oldGeo == undefined || newGeo[0] != oldGeo[0] || newGeo[1] != oldGeo[1]) {
+		if (newGeo[0] != oldGeo[0] || newGeo[1] != oldGeo[1]) {
 			item.set(paths.geo, newGeo);
 		}
 		


### PR DESCRIPTION
Fix a error produced when create entity without enter a location field type and modify this entity after because oldGeo is null

if (newGeo[0] != oldGeo[0] || newGeo[1] != oldGeo[1]) {
                               ^
TypeError: Cannot read property '0' of undefined
