### PR TITLE
keystone error on blank date / date time  fields

### DIFF
--- a/lib/fieldTypes/date.js
+++ b/lib/fieldTypes/date.js
@@ -86,7 +86,7 @@ date.prototype.validateInput = function(data, required, item) {
 	
 	if (required && (!newValue || !newValue.isValid())) {
 		return false;
-	} else if (newValue && !newValue.isValid()) {
+	} else if (data[this.path] && newValue && !newValue.isValid()) {
 		return false;
 	} else {
 		return true;

--- a/lib/fieldTypes/datetime.js
+++ b/lib/fieldTypes/datetime.js
@@ -112,7 +112,7 @@ datetime.prototype.validateInput = function(data, required, item) {
 	
 	if (required && (!newValue || !newValue.isValid())) {
 		return false;
-	} else if (newValue && !newValue.isValid()) {
+	} else if (this.getInputFromData(data) && newValue && !newValue.isValid()) {
 		return false;
 	} else {
 		return true;


### PR DESCRIPTION
Changes are not saved when editing an item in keystone when date or datetime fields are empty, a validation error is generated in the interface on those fields.
