### PR TITLE
Fix the columns filter button position in development env

### DIFF
--- a/templates/views/list.jade
+++ b/templates/views/list.jade
@@ -142,7 +142,8 @@ block content
 					//- lg screens only
 					//- columns and download aren't relevant when using a mobile device
 					.col-sm-4.hidden-xs: .pull-right
-						a(href='/keystone/download/#{list.path}').btn.btn-default.pull-right Download
+						.pull-right
+							a(href='/keystone/download/#{list.path}').btn.btn-default Download
 						div(style='margin-right: 10px;').dropdown.list-columns-dropdown.pull-right
 							a(href=js, data-toggle='dropdown').btn.btn-default.dropdown-toggle
 								| Columns 


### PR DESCRIPTION
The button incorrectly appears under the download button in Chrome.
Pretty print whitespace issue, works in production, but not in development.
Seems to be only affecting Chrome (both mac+pc). Looks fine in Firefox + IE
