### PR TITLE
Add try/catch for missing Pre-route middleware

### DIFF
--- a/index.js
+++ b/index.js
@@ -411,7 +411,13 @@ Keystone.prototype.start = function(onStart) {
 	// Pre-route middleware
 	
 	this._pre.routes.forEach(function(fn) {
-		app.use(fn);
+		try {
+			app.use(fn);	
+		}
+		catch(e) {
+			console.log('Pre-route middleware (not found):');
+			console.log(e);
+		}
 	});
 	
 	// Route requests


### PR DESCRIPTION
Added try/catch as it throws an obscure error otherwise, eg: TypeError: Cannot read property 'handle' of undefined
