### PR TITLE
Added docs for Mandrill Service and fixed typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Keystone gives you:
 	natively supported by Mongoose
 *	An updates framework for managing data updates or initialisation
 *	A beautiful Admin UI based on the defined `models`
-*	Integration with Coudinary for image uploading, storage and resizing
+*	Integration with Cloudinary for image uploading, storage and resizing
 *	Integration with Mandrill for sending emails easily
 *	Integration with Embedly for powerful video and rich media embedding tools
 

--- a/docs/content/templates/views/configuration.jade
+++ b/docs/content/templates/views/configuration.jade
@@ -257,6 +257,22 @@ block content
 			
 			pre: code.language-javascript
 				| keystone.set('embedly api key', 'your-key');
+
+
+			a(name='mandrill')
+			h3 Mandrill
+			p <a href="http://mandrill.com" target="_blank">Mandrill</a> is a scalable and affordable email infrastructure service that allows you to send emails easily. They offer a free plan for up to 12,000
+			emails per month.
+
+			p To configure KeystoneJS to support the Mandrill API, simply <a href="https://mandrill.com/signup/">sign up for an account</a>, get your api key, and set both the <code>mandrill api key</code> and <code>mandrill username</code> options.
+			
+			p These options will default to the <code class="default-value">MANDRILL_API_KEY & MANDRILL_USERNAME</code> environment variable's if set.
+
+			pre: code.language-javascript
+				| keystone.set('mandrill api key', 'your-key');
+				| keystone.set('mandrill username', 'your-username');
+
+
 			
 			
 			//- h2 Error Handling


### PR DESCRIPTION
Noticed docs for Mandrill Service were missing so I added them, wanted to clarify about this

" \* Options:
- 
- \- mandrill
-   Initialised Mandrill API instance
- 
- \- tags
-   Array of tags to send to Mandrill
- 
  "

Should I mention something about the tags options? 
