### PR TITLE
httpServer accessable

### DIFF
--- a/index.js
+++ b/index.js
@@ -537,7 +537,8 @@ Keystone.prototype.start = function(onStart) {
 		
 		// Create the http server
 		var listen = function() {
-			http.createServer(app).listen(app.get('port'), app.get('host'), function() {
+			keystone.httpServer = http.createServer(app);
+			keystone.httpServer.listen(app.get('port'), app.get('host'), function() {
 				console.log(keystone.get('name') + ' is ready on port ' + app.get('port'));
 				if ('function' == typeof onStart)
 					onStart();


### PR DESCRIPTION
Not sure that you guys already talked about it or want this stuff but it seems like it is impossible at the moment to hook something like socket.io up.

With this small commit the server is accessible and it's easy to hook something like socket.io in the callback up.
