### PR TITLE
Add create view (initial: true) support for Types.Markdown #155

### DIFF
--- a/templates/fields/markdown/initial.jade
+++ b/templates/fields/markdown/initial.jade
@@ -1,0 +1,6 @@
+.field.type-markdown
+    label.field-label= field.label
+    .field-ui(class='width-' + field.width)
+        textarea(name=field.path, style='height: #{field.height}px').form-control.code= item[field.path]
+        if field.note
+            .field-note= field.note


### PR DESCRIPTION
Add `initial.jade` to fix issue #155 and allow Markdown to be used in a create view.
