### PR TITLE
Fixes "moment not defined" error in S3File field type.

### DIFF
--- a/lib/fieldTypes/s3file.js
+++ b/lib/fieldTypes/s3file.js
@@ -3,6 +3,7 @@
  */
 
 var _ = require('underscore'),
+	moment = require('moment'),
 	keystone = require('../../'),
 	async = require('async'),
 	util = require('util'),


### PR DESCRIPTION
Error occurs when one uses the datePrefix option on the S3File type.
