### PR TITLE
Adding ability to define attachments to emails via Mandrill.

### DIFF
--- a/lib/email.js
+++ b/lib/email.js
@@ -324,6 +324,7 @@ Email.prototype.send = function(locals, options, callback) {
 			from_name: options.fromName,
 			from_email: options.fromEmail,
 			tags: options.tags,
+			attachments: options.attachments,
 			to: recipients,
 			merge_vars: mergeVars,
 			track_opens: true,


### PR DESCRIPTION
Ideally all options of the Mandrill API should be able to captured and set, preserve_recipients is another good example, currently hardcoded to false. Adding ability to define attachments for the time being.
