### PR TITLE
Adding supported types to cloudinary images.

### DIFF
--- a/public/js/common/ui-cloudinaryimage.js
+++ b/public/js/common/ui-cloudinaryimage.js
@@ -58,7 +58,7 @@ jQuery(function($) {
 				if (window.FileReader) {
 					var files = e.target.files;
 					for (var i = 0, f; f = files[i]; i++) {
-						if (jQuery.inArray(f.type, supportedTypes) < 0) {
+						if (!_.contains(supportedTypes, f.type)) {
 							$upload.val('');
 							alert("Unsupported file type. Supported formats are: GIF, PNG, JPG, BMP, ICO, PDF, TIFF, EPS, PSD");
 							continue;

--- a/public/js/common/ui-cloudinaryimages.js
+++ b/public/js/common/ui-cloudinaryimages.js
@@ -1,4 +1,5 @@
 jQuery(function($) {
+	var supportedTypes = ['image/gif', 'image/png', 'image/jpeg', 'image/bmp', 'image/x-icon', 'application/pdf', 'image/x-tiff', 'image/x-tiff', 'application/postscript', 'image/vnd.adobe.photoshop'];
 	
 	// Cloudinary Images
 	$('.field.type-cloudinaryimages').each(function() {
@@ -182,10 +183,10 @@ jQuery(function($) {
 			if (imagePreviews) {
 				async.each(files, function(f, next) {
 					
-					if (!f.type.match('image.*')) {
+					if (!_.contains(supportedTypes, f.type)) {
 						$field.remove();
 						checkQueues();
-						alert("Please select image files only.");
+						alert("Unsupported file type. Supported formats are: GIF, PNG, JPG, BMP, ICO, PDF, TIFF, EPS, PSD");
 						return next();
 					}
 					


### PR DESCRIPTION
Similar to #109, add ability to upload all supported formats for Cloudinary.

List taken from http://support.cloudinary.com/entries/23462458-What-type-of-image-formats-do-you-support- 

Some contention around the correct mime type for a PSD format. Some list it as `image/vnd.adobe.photoshop` others as `application/octet-stream`. I went with the former as I didn't want to use the latter. But I am not using PSD format files so this is not an issue for me but may be for others.
