### PR TITLE
Respect the List property 'hidden' for non-flat Navigation. #166

### DIFF
--- a/templates/views/home.jade
+++ b/templates/views/home.jade
@@ -14,11 +14,13 @@ block content
 			.nav-section
 				h4= navSection.label
 				each list in navSection.lists
-					h3: a(href='/keystone/' + list.path)= list.label
+					if (!list.get('hidden'))
+						h3: a(href='/keystone/' + list.path)= list.label
 		if orphanedLists.length
 			.nav-section
 				h4 Other
 				each list in orphanedLists
-					h3: a(href='/keystone/' + list.path)= list.label
+					if (!list.get('hidden'))
+						h3: a(href='/keystone/' + list.path)= list.label
 		
 		


### PR DESCRIPTION
I found that if you did not have the Flat Navigation it still showed the hidden Lists but you would get an error when trying to access them.
