### PR TITLE
update email templates to support multiple template engines

### DIFF
--- a/lib/email.js
+++ b/lib/email.js
@@ -49,6 +49,8 @@ var getEmailsPath = function(){
 	}
 };
 
+process.nextTick(getEmailsPath);
+
 /**
  * Email Class
  * ===========
@@ -179,14 +181,14 @@ Email.prototype.render = function(locals, callback) {
 Email.prototype.loadTemplate = function(callback) {
 
 	var self = this,
-		fsTemplatePath = path.join(Email.getEmailsPath(), self.templateName + self.templateExt);
+		fsTemplatePath = path.join(Email.getEmailsPath(), self.templateName + '.' + self.templateExt);
 
 	fs.readFile(fsTemplatePath, function(err, contents) {
 
 		if (err) {
 			if (err.code == 'ENOENT') {
 
-				fsTemplatePath = path.join(Email.getEmailsPath(), self.templateName, 'email'+self.templateExt);
+				fsTemplatePath = path.join(Email.getEmailsPath(), self.templateName, 'email.'+self.templateExt);
 
 				fs.readFile(fsTemplatePath, function(err, contents) {
 					callback(err, fsTemplatePath, contents);
@@ -222,7 +224,7 @@ Email.prototype.compileTemplate = function(callback) {
 
 		if (err) return callback(err);
 
-		var template = self.templateEngine.compile(contents, { filename: fs.realpathSync(filename), basedir: self.templateBasePath });
+		var template = self.templateEngine.compile(contents.toString(), Email.defaults.compilerOptions||{ filename: fs.realpathSync(filename), basedir: self.templateBasePath });
 
 		templateCache[self.templateName] = template;
 
@@ -263,7 +265,6 @@ Email.prototype.compileTemplate = function(callback) {
  */
 
 Email.prototype.send = function(locals, options, callback) {
-
 	var self = this;
 
 	this.render(locals, function(err, email) {
@@ -285,12 +286,12 @@ Email.prototype.send = function(locals, options, callback) {
 		if ('string' == typeof options.from) {
 			options.fromName = options.from;
 			options.fromEmail = options.from;
-		} else if ('object' == typeof options.from) {
+		} else if ((options.from||{}).name) {
 			options.fromName = ('object' == typeof options.from.name) ? options.from.name.full : options.from.name;
 			options.fromEmail = options.from.email;
 		}
 
-		if (!options.fromName || !options.fromEmail) {
+		if (!(options.fromName && options.fromEmail)) {
 			return callback({
 				from: 'Email.send',
 				key: 'invalid options',
@@ -380,7 +381,7 @@ Email.prototype.send = function(locals, options, callback) {
 			async: true
 		};
 
-		_.defaults(message, options.mandrill);
+		_.defaults(message, options.mandrillOptions);
 		_.defaults(message, Email.defaults.mandrill);
 
 		options.mandrill.messages.send({ message: message }, onSuccess, onFail);


### PR DESCRIPTION
This PR takes the existing email.js and allows it to support multiple template engines.  You can see an example using handlebars at https://github.com/jdarling/kcsbd-keystone in the server.js and modles/enquires.js files.

Also introduces new Error types for common error types.  Probably should extend these into some of the callback error's, but for now this works well.

Working on a better solution for the problem of binding into models for model changes such as insert, update, edit, and delete.  That will be a completely different module as it completely breaks the current email solution.
