### PR TITLE
Relationship fields return blank when related item is missing - console ...

### DIFF
--- a/routes/api/list.js
+++ b/routes/api/list.js
@@ -95,7 +95,7 @@ exports = module.exports = function(req, res) {
 			req.list.model.findById(req.query.id).exec(function(err, item) {
 				
 				if (err) return sendError('database error', err);
-				if (!item) return sendError('not found');
+				if (!item) return sendResponse({ name: req.query.id, id: req.query.id });
 				
 				switch (req.query.dataset) {
 					case 'simple':


### PR DESCRIPTION
...err is: API Error (not found)

When an Item is removed, but the relationship in another list is not cleaned up for that item, the related item screen returns the console error: API Error (not found) and nothing is displayed in the relationship field. 

This happens on fields that are many:true.

eg: if I have 2 models, listings and categories and categories have a relationship field for listings with many:true option.

If 10 listings are then linked to a category and I delete 1 listing, the remaining 9 should display, with the last one returned displaying its ID so it can be removed from the list and updated, currently none display.

This pull request just sends the id back so you can clean it up.
