### PR TITLE
Trigger mongoose middleware when removing items

### DIFF
--- a/routes/api/list.js
+++ b/routes/api/list.js
@@ -181,17 +181,21 @@ exports = module.exports = function(req, res) {
 			
 			var id = req.body.id || req.query.id;
 			
-			req.list.model.findById(id).remove(function(err, count) {
-				
-				if (err) return sendError('database error', err);
-				if (!count) return sendError('not found');
-				
-				return sendResponse({
-					success: true,
-					count: count
-				});
-				
-			});
+      req.list.model.findById(id).exec(function (err, item) {
+
+        if (err) return sendError('database error', err);
+        if (!item) return sendError('not found');
+
+        item.remove(function (err) {
+          if (err) return sendError('database error', err);
+
+          return sendResponse({
+            success: true,
+            count: 1
+          });
+        });
+        
+      });
 			
 		break;
 		

--- a/routes/views/list.js
+++ b/routes/views/list.js
@@ -160,12 +160,16 @@ exports = module.exports = function(req, res) {
 	}
 	
 	if (!req.list.get('nodelete') && req.query['delete']) {
-		req.list.model.findById(req.query['delete']).remove(function(err, count) {
-			if (count) {
-				req.flash('success', req.list.singular + ' deleted successfully.');
-			}
-			res.redirect('/keystone/' + req.list.path);
-		});
+    req.list.model.findById(req.query['delete']).exec(function (err, item) {
+      if (err || !item) return res.redirect('/keystone/' + req.list.path);
+
+      item.remove(function (err) {
+        if (!err) {
+          req.flash('success', req.list.singular + ' deleted successfully.');
+        }
+        res.redirect('/keystone/' + req.list.path);
+      });
+    });
 		
 		return;
 	}


### PR DESCRIPTION
This change ensures that mongoose middleware is triggered when items are removed from a list (via the API, or the admin interface).
