### PR TITLE
Adding tags to Cloudinary direct uploads

### DIFF
--- a/index.js
+++ b/index.js
@@ -1046,7 +1046,9 @@ Keystone.prototype.render = function(req, res, view, ext) {
 				cloud_name: keystone.get('cloudinary config').cloud_name,
 				api_key: keystone.get('cloudinary config').api_key,
 				timestamp: cloudinaryUpload.hidden_fields.timestamp,
-				signature: cloudinaryUpload.hidden_fields.signature
+				signature: cloudinaryUpload.hidden_fields.signature,
+				prefix: keystone.get('cloudinary prefix') || '',
+				uploader: cloudinary.uploader
 			};
 			locals.cloudinary_js_config = cloudinary.cloudinary_js_config();
 		} catch(e) {

--- a/templates/fields/cloudinaryimages/form.jade
+++ b/templates/fields/cloudinaryimages/form.jade
@@ -1,10 +1,20 @@
 - var hasImages = item.get(field.path).length
+- var p = cloudinary.prefix;
+- if (p.length)
+	- p += '_';
+- var tags = [p + field.list.path + '_' + field.path, p + field.list.path + '_' + field.path + '_' + item.id];
+- if (cloudinary.prefix)
+	- tags.push(cloudinary.prefix);
+- if (env != 'production')
+	- tags.push(p + 'dev');
+- var directUpload = cloudinary.uploader.direct_upload(undefined,{tags:tags})
+- var formData = {cloud_name: cloudinary.cloud_name, api_key: cloudinary.api_key, timestamp: directUpload.hidden_fields.timestamp, signature: directUpload.hidden_fields.signature, tags: tags}
 .field.type-cloudinaryimages(data-field-type=field.type, data-field-path=field.path, data-field-paths-upload=field.paths.upload, data-field-paths-uploads=field.paths.uploads, data-field-collapse=field.collapse ? 'true' : false, data-field-depends-on=field.dependsOn, data-field-noedit=field.noedit ? 'true' : 'false', data-field-value=hasImages ? 'true' : 'false')
 	label.field-label= field.label
 	input(type='hidden', name=field.paths.action, value='').field-action
 	input(type='hidden', name=field.paths.order, value='').field-order
 	input(type='hidden', name=field.paths.uploads, value='').field-uploads
-	input(type='file', name='file', multiple, data-form-data='#{JSON.stringify(cloudinary)}').field-upload
+	input(type='file', name='file', multiple, data-form-data='#{JSON.stringify(formData)}').field-upload
 	.field-ui(class=hasImages ? 'has-image' : false)
 		if field.noedit
 			each value in item.get(field.path)


### PR DESCRIPTION
Had to generate a new timestamp + signature for each cloudinaryimages field in the list and pass as form data on the file input.
This required exposing `cloudinary.uploader` in `locals.cloudinary` so each field could run `direct_upload()` again with the tags as one of the options - resulting in a new signature.
The default timestamp + signature used by `jquery.cloudinary.js`, defined in a `script` tag on the base template does not support tags as there could be more than one cloudinaryimages field per list.
