### PR TITLE
Fixed 'Can't set headers after they are sent.' exception on /keystone/[list]/?new

### DIFF
--- a/routes/views/list.js
+++ b/routes/views/list.js
@@ -6,34 +6,34 @@ var keystone = require('../../'),
 	utils = require('keystone-utils');
 
 exports = module.exports = function(req, res) {
-	
+
 	var viewLocals = {
 		validationErrors: {},
 		showCreateForm: _.has(req.query, 'new')
 	};
-	
+
 	var sort = { by: req.query.sort || req.list.defaultSort },
 		filters = (req.query.q) ? req.list.processFilters(req.query.q) : {},
 		queryFilters = req.list.getSearchFilters(req.query.search, filters),
 		columns = (req.query.cols) ? req.list.expandColumns(req.query.cols) : req.list.defaultColumns;
-	
+
 	if (sort.by) {
-		
+
 		sort.inv = sort.by.charAt(0) == '-';
 		sort.path = (sort.inv) ? sort.by.substr(1) : sort.by;
 		sort.field = req.list.fields[sort.path];
-		
+
 		var clearSort = function() {
 			delete req.query.sort;
 			var qs = querystring.stringify(req.query);
 			return res.redirect(req.path + ((qs) ? '?' + qs : ''));
 		}
-		
+
 		// clear the sort query value if it is the default sort value for the list
 		if (req.query.sort == req.list.defaultSort) {
 			return clearSort();
 		}
-		
+
 		if (sort.field) {
 			// the sort is set to a field, use its label
 			sort.label = sort.field.label;
@@ -48,15 +48,15 @@ exports = module.exports = function(req, res) {
 			// it looks like an invalid path has been specified (no matching field), so clear the sort
 			return clearSort();
 		}
-		
+
 	}
-	
+
 	var renderView = function() {
-		
+
 		var query = req.list.paginate({ filters: queryFilters, page: req.params.page }).sort(sort.by);
-		
+
 		req.list.selectColumns(query, columns);
-		
+
 		var link_to = function(params) {
 			var p = params.page || '';
 			delete params.page;
@@ -70,27 +70,27 @@ exports = module.exports = function(req, res) {
 			params = querystring.stringify(_.defaults(params, queryParams));
 			return '/keystone/' + req.list.path + (p ? '/' + p : '') + (params ? '?' + params : '');
 		}
-		
+
 		query.exec(function(err, items) {
-			
+
 			if (err) {
 				console.log(err);
 				return res.status(500).send("Error querying items:<br><br>" + JSON.stringify(err));
 			}
-			
+
 			// if there were results but not on this page, reset the page
 			if (req.params.page && items.total && !items.results.length) {
 				return res.redirect('/keystone/' + req.list.path);
 			}
-			
+
 			// go straight to the result if there was a search, and only one result
 			if (req.query.search && items.total == 1 && items.results.length == 1) {
 				return res.redirect('/keystone/' + req.list.path + '/' + items.results[0].id);
 			}
-			
+
 			var download_link = '/keystone/download/' + req.list.path,
 				downloadParams = {};
-			
+
 			if (req.query.q) {
 				downloadParams.q = req.query.q;
 			}
@@ -100,17 +100,17 @@ exports = module.exports = function(req, res) {
 			if (req.query.cols) {
 				downloadParams.cols = req.query.cols;
 			}
-			
+
 			downloadParams = querystring.stringify(downloadParams);
-			
+
 			if (downloadParams) {
 				download_link += '?' + downloadParams;
 			}
-			
+
 			var compileFields = function(item, callback) { item.compile('initial', callback); }
-			
+
 			async.eachSeries(req.list.initialFields, compileFields , function() {
-				
+
 				keystone.render(req, res, 'list', _.extend(viewLocals, {
 					section: keystone.nav.by.list[req.list.key] || {},
 					title: 'Keystone: ' + req.list.plural,
@@ -127,12 +127,12 @@ exports = module.exports = function(req, res) {
 					submitted: req.body || {},
 					query: req.query
 				}));
-				
+
 			});
 		});
-		
+
 	}
-	
+
 	if ('update' in req.query) {
 		(function() {
 			var data = null;
@@ -155,11 +155,9 @@ exports = module.exports = function(req, res) {
 				res.redirect('/keystone/' + req.list.path);
 			});
 		})();
-		
+
 		return;
-	}
-	
-	if (!req.list.get('nodelete') && req.query['delete']) {
+	} else if (!req.list.get('nodelete') && req.query['delete']) {
 		req.list.model.findById(req.query['delete']).exec(function (err, item) {
 			if (err || !item) return res.redirect('/keystone/' + req.list.path);
 
@@ -170,15 +168,13 @@ exports = module.exports = function(req, res) {
 				res.redirect('/keystone/' + req.list.path);
 			});
 		});
-		
+
 		return;
-	}
-	
-	if (!req.list.get('nocreate') && _.has(req.query, 'new')) {
-		
+	} else if (!req.list.get('nocreate') && _.has(req.query, 'new')) {
+
 		var item = new req.list.model();
 		item.save(function(err) {
-			
+
 			if (err) {
 				console.log('There was an error creating the new ' + req.list.singular + ':');
 				console.log(err);
@@ -188,23 +184,23 @@ exports = module.exports = function(req, res) {
 				req.flash('success', 'New ' + req.list.singular + ' ' + req.list.getDocumentName(item) + ' created.');
 				return res.redirect('/keystone/' + req.list.path + '/' + item.id);
 			}
-			
+
 		});
-		
+
 	} else if (!req.list.get('nocreate') && req.method == 'POST' && req.body.action == 'create') {
-		
+
 		var item = new req.list.model(),
 			updateHandler = item.getUpdateHandler(req);
-		
+
 		viewLocals.showCreateForm = true; // always show the create form after a create. success will redirect.
-		
+
 		if (req.list.nameIsInitial) {
 			if (req.list.nameField.validateInput(req.body))
 				req.list.nameField.updateItem(item, req.body);
 			else
 				updateHandler.addValidationError(req.list.nameField.path, 'Name is required.');
 		}
-		
+
 		updateHandler.process(req.body, {
 			flashErrors: true,
 			logErrors: true,
@@ -216,11 +212,10 @@ exports = module.exports = function(req, res) {
 			req.flash('success', 'New ' + req.list.singular + ' ' + req.list.getDocumentName(item) + ' created.');
 			return res.redirect('/keystone/' + req.list.path + '/' + item.id);
 		});
-		
+
 		return;
-		
+
+	} else {
+		renderView();
 	}
-	
-	renderView();
-	
 }


### PR DESCRIPTION
When clicking the 'new something' button on the item view, `renderView` is called twice inside `list.js` and causing express to throw 'Can't set headers after they are sent.' exception. This crashes the server.

This pull fixes it, but one issue still remains. If the model you are creating have required fields, an exception is thrown from mongoose. This does not crash the server, but no model is created.

Perhaps the button should be removed, and save takes you back to the list view?
