### PR TITLE
The from parameter redirect on signin is not validated and allows for open redirects.

### DIFF
--- a/routes/views/signin.js
+++ b/routes/views/signin.js
@@ -21,7 +21,7 @@ exports = module.exports = function(req, res) {
 		
 		var onSuccess = function(user) {
 			
-			if (req.query.from) {
+			if (req.query.from  && req.query.from.match(/^(?!http|\/\/|javascript).+/)) {
 				res.redirect(req.query.from);
 			} else if ('string' == typeof keystone.get('signin redirect')) {
 				res.redirect(keystone.get('signin redirect'));


### PR DESCRIPTION
Hi there, 

I'm really enjoying working with Keystone, and have been very impressed with it.  I did notice something with the redirect following sign-in.

The req.querystring.from parameter is not validated.  It will redirect the user to any url. It is vulnerable to an open redirect. This page has more details https://www.owasp.org/index.php/Top_10_2013-A10-Unvalidated_Redirects_and_Forwards 

I've added a test to ensure that the value in req.querystring.from is a relative address to the site.  The test will prevent redirects to URLs in the following form;
- http://www.example.com
- https://www.example.com
- http://example.com
- https://example.com
- //www.example.com
- //example.com
- javascript:window.location.href="http://example.com"

and allow the redirects to URLs similar to the following
- /
- /my/page
- /mypage
- mypage
- ../../mypage
- ../mypage
- ?page=this 

Hope this is of use?  

Oliver
