### PR TITLE
Set up tests and add them for Path.

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,3 @@
 docs
 examples
-tests
+/test/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,20 @@
+NODE_OPTS :=
+TEST_OPTS :=
+
+love:
+	@echo "What would you like to do today?"
+
+test:
+	@node $(NODE_OPTS) ./node_modules/.bin/_mocha -R dot $(TEST_OPTS)
+
+spec:
+	@node $(NODE_OPTS) ./node_modules/.bin/_mocha -R spec $(TEST_OPTS)
+
+autotest:
+	@node $(NODE_OPTS) ./node_modules/.bin/_mocha -R dot --watch $(TEST_OPTS)
+
+autospec:
+	@node $(NODE_OPTS) ./node_modules/.bin/_mocha -R spec --watch $(TEST_OPTS)
+
+.PHONY: love
+.PHONY: test spec autotest autospec

--- a/package.json
+++ b/package.json
@@ -29,6 +29,10 @@
     "azure": "~0.8.1",
     "range_check": "~0.0.4"
   },
+  "devDependencies": {
+    "mocha": ">= 1.12 < 2",
+    "must": ">= 0.11 < 1"
+  },
   "author": "Jed Watson",
   "license": "MIT",
   "keywords": [
@@ -46,6 +50,9 @@
   "gitHead": "ef3fd612285315ea8e12f68da4c8d6031e2c7fe7",
   "bugs": {
     "url": "https://github.com/JedWatson/keystone/issues"
+  },
+  "scripts": {
+    "test": "make test"
   },
   "engines": {
     "node": "0.10.x",

--- a/test/dates.js
+++ b/test/dates.js
@@ -1,3 +1,5 @@
+if (module.parent) return;
+
 /**
 	These tests are currently designed to be run from the command line like
 	`/keystone/tests node dates`

--- a/test/fields.js
+++ b/test/fields.js
@@ -1,3 +1,5 @@
+if (module.parent) return;
+
 /**
 	These tests are currently designed to be run from the command line like
 	`/keystone/tests node fields`

--- a/test/lib/path_test.js
+++ b/test/lib/path_test.js
@@ -1,0 +1,81 @@
+var Path = require("../../lib/path")
+
+describe("Path", function() {
+	describe("new", function() {
+		it("must be an instance of Path", function() {
+			new Path("").must.be.an.instanceof(Path)
+		})
+	})
+
+	describe(".prototype.append", function() {
+		it("must return the path appended to the given part", function() {
+			var path = new Path("foo.example.dir")
+			path.append(".com").must.equal("foo.example.dir.com")
+		})
+	})
+
+	describe(".prototype.addTo", function() {
+		it("must return an hierarchical object from path", function() {
+			var path = new Path("foo.example.dir.file")
+			var obj = path.addTo({}, 42)
+			obj.must.eql({foo: {example: {dir: {file: 42}}}})
+		})
+
+		it("must merge given an existing hierarchy", function() {
+			var path = new Path("foo.example.dir.file")
+			var obj = path.addTo({foo: {example: {link: 69}}}, 42)
+			obj.must.eql({foo: {example: {link: 69, dir: {file: 42}}}})
+		})
+	})
+
+	describe(".prototype.get", function() {
+		it("must walk hierarchy and return value", function() {
+			var path = new Path("foo.example.dir")
+			path.get({foo: {example: {dir: 42}}}).must.equal(42)
+		})
+	})
+
+	describe(".prototype.prependToLast", function() {
+		it("must return path with preprended last part", function() {
+			var path = new Path("foo.example.dir")
+			path.prependToLast("cool").must.equal("foo.example.cooldir")
+		})
+
+		it("must return path with last part in titlecase given true", function() {
+			var path = new Path("foo.example.dir")
+			path.prependToLast("cool", true).must.equal("foo.example.coolDir")
+		})
+
+		it("must return path with last part as-is given false", function() {
+			var path = new Path("foo.example.dir")
+			path.prependToLast("cool", false).must.equal("foo.example.cooldir")
+		})
+	})
+
+	describe(".prototype.flatten", function() {
+		it("must return path camel cased given false", function() {
+			var path = new Path("foo.example.dir")
+			path.flatten(false).must.equal("FooExampleDir")
+		})
+
+		it("must return path camel cased with lowercase first letter given true",
+			function() {
+			var path = new Path("foo.example.dir")
+			path.flatten(true).must.equal("fooExampleDir")
+		})
+	})
+
+	describe("last", function() {
+		it("must equal to the last part of path", function() {
+			var path = new Path("foo.example.dir")
+			path.last.must.equal("dir")
+		})
+	})
+
+	describe("exceptLast", function() {
+		it("must equal to the path without last part", function() {
+			var path = new Path("foo.example.dir")
+			path.exceptLast.must.equal("foo.example")
+		})
+	})
+})

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,0 +1,2 @@
+--recursive
+--require must

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,3 +1,5 @@
+if (module.parent) return;
+
 /**
 	These tests are currently designed to be run from the command line like
 	`/keystone/tests node utils`


### PR DESCRIPTION
As per suggestion from you-know-who, here's to a good start of unit tests for Keystone.js! ;-)
- Added tests for the `Path` class. It was independent and easy to get going.  
  That's also a useful way to get into unit testing — pick some low hanging fruit. And in no time you'll be at >90% coverage. ;-)
- Threw in a Makefile for quick access and keeping it simple. Just invoke `make test`.  
- Renamed `/tests` to `/test` as a couple of those testing tools default to it.  
  If you're keen on having the folder name in plural, I'm sure there's a way somewhere.
- Used tabs as per `.editorconfig`.
- Missed semicolons in tests. :-/  
  If only JS had a way to add them automatically... something like an automatic semicolon insertion mechanism. ^_^ But seriously, if you find those are necessary, I can cobble up a sed script and sprinkle some. :)

Let me know if you've got any questions.

PS. And yes, Must.js comes with support! Both on-site and over voice calls.
