### PR TITLE
Add S3_REGION parameter for non default S3 regions

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,7 +64,7 @@ var Keystone = function() {
 	this.set('allowed ip ranges', process.env.ALLOWED_IP_RANGES);
 	
 	if (process.env.S3_BUCKET && process.env.S3_KEY && process.env.S3_SECRET) {
-		this.set('s3 config', { bucket: process.env.S3_BUCKET, key: process.env.S3_KEY, secret: process.env.S3_SECRET });
+		this.set('s3 config', { bucket: process.env.S3_BUCKET, key: process.env.S3_KEY, secret: process.env.S3_SECRET, region: process.env.S3_REGION });
 	}
 
 	if (process.env.AZURE_STORAGE_ACCOUNT && process.env.AZURE_STORAGE_ACCESS_KEY) {


### PR DESCRIPTION
Someone can set S3_REGION in environment variables, for example:
S3_REGION=eu-west-1
