### PR TITLE
Update list.js

### DIFF
--- a/routes/views/list.js
+++ b/routes/views/list.js
@@ -53,7 +53,7 @@ exports = module.exports = function(req, res) {
 
 	var renderView = function() {
 
-		var query = req.list.paginate({ filters: queryFilters, page: req.params.page }).sort(sort.by);
+		var query = req.list.paginate({ filters: queryFilters, page: req.params.page, perPage: req.list.get('perPage') }).sort(sort.by);
 
 		req.list.selectColumns(query, columns);
 


### PR DESCRIPTION
List setting for pagination. Just set for example {perPage: 300} in List options.

Here is an example usage:
Doge = new keystone.List("Doge",{
perPage: 300,
defaultColumns: "name,wow",
sortable: true})

This will make keystone admin lists paginate by 300 for the type Doge.
