### PR TITLE
Only show "Open Keystone" link to admins

### DIFF
--- a/templates/views/signin.jade
+++ b/templates/views/signin.jade
@@ -11,7 +11,8 @@ block content
 				p.lead Hi #{user.name.first},
 				p.lead You're already signed in.
 				.toolbar
-					a(href='/keystone').btn.btn-primary Open Keystone
+					if user.isAdmin
+						a(href='/keystone').btn.btn-primary Open Keystone
 					a(href='/keystone/signout').btn.btn-cancel Sign out
 			
 			else


### PR DESCRIPTION
Why show the link to non-admins if they're going to be denied anyway?
