### PR TITLE
Fixed dead url to working in error report

### DIFF
--- a/lib/fieldTypes/s3file.js
+++ b/lib/fieldTypes/s3file.js
@@ -42,7 +42,7 @@ function s3file(list, path, options) {
 	if (!this.s3config) {
 		throw new Error('Invalid Configuration\n\n' +
 			'S3File fields (' + list.key + '.' + path + ') require the "s3 config" option to be set.\n\n' + 
-			'See http://keystonejs.com/docs/configuration#amazons3 for more information.\n');
+			'See http://keystonejs.com/docs/configuration/#services-amazons3 for more information.\n');
 	}
 	
 	// Could be more pre- hooks, just upload for now


### PR DESCRIPTION
Fixed Amazon S3 dead url in keystone docs to working
