### PR TITLE
Catching errors on deletion.

### DIFF
--- a/routes/views/list.js
+++ b/routes/views/list.js
@@ -163,7 +163,11 @@ exports = module.exports = function(req, res) {
 			if (err || !item) return res.redirect('/keystone/' + req.list.path);
 
 			item.remove(function (err) {
-				if (!err) {
+				if (err) {
+					console.log('Error deleting ' + req.list.singular);
+					console.log(err);
+					req.flash('error', 'There was an error deleting ' + req.list.singular + ' (logged to console)');
+				} else {
 					req.flash('success', req.list.singular + ' deleted successfully.');
 				}
 				res.redirect('/keystone/' + req.list.path);


### PR DESCRIPTION
Fixed the fact that error wasn't handled when deleting an item. 
In a project, I had to sync backend with an external Cloud. I used mongoose middleware (pre-remove) to try deleting the same item on the cloud. If something go wrong or deletion is locked (this happens when something is pending), I pass an error to next(). It cancels the deletion, but no message was prompt (flash or console).
