### PR TITLE
Removed useless verification on single element

### DIFF
--- a/routes/views/item.js
+++ b/routes/views/item.js
@@ -9,10 +9,6 @@ exports = module.exports = function(req, res) {
 	
 	req.list.model.findById(req.params.item).exec(function(err, item) {
 		
-		if (Array.isArray(item)) {
-			item = item[0]; // WTF??? I thought findById was only meant to return a single document.
-		}
-		
 		if (!item) {
 			req.flash('error', 'Item ' + req.params.item + ' could not be found.');
 			return res.redirect('/keystone/' + req.list.path);


### PR DESCRIPTION
I don't know what was causing findById to return more than one entry when this verification was written, but according to mongoose documentation and my tests in Keystone, this condition (Array.isArray(item)) never returns true in any case (when displaying the view, saving an item, or trying to edit an item that doesn't exist). Of course, I assume that ids are unique, if that's not the case (is that even possible ?), we should handle this error more explicitly.
