### PR TITLE
Clearer editorconfig definition around indentation

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,6 +7,8 @@ end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = false
 insert_final_newline = true
+indent_style = tab
+indent_size = 4
 
 [*.jade]
 indent_style = tab
@@ -14,4 +16,8 @@ indent_size = 4
 
 [*.less]
 indent_style = tab
+indent_size = 2
+
+[*.json]
+indent_style = space
 indent_size = 2


### PR DESCRIPTION
Not all editors have auto-detection enabled, so good to have the expectations clearly defined, those expectations being:
- tabs by default
- 2 spaces for json (npm really dislikes anything else)
