### PR TITLE
fix view.on({})

### DIFF
--- a/lib/view.js
+++ b/lib/view.js
@@ -74,7 +74,7 @@ View.prototype.on = function(on) {
 				ctx = ctx[parts[i]];
 			}
 
-			return (value === true && path in ctx) ? true : (ctx[path] == value);
+			return (value === true && path in ctx) ? true : (ctx === value);
 
 		};
 


### PR DESCRIPTION
I'm pretty sure I found a bug and fixed it. Let me know if I'm totally wrong.

view.on should let this happen:

``` javascript
view.on({'user.name.first': 'Admin'}, function (next) {
  console.log('hello admin')
  next()
})
```

and that wasn't working so I dug into it and made it work. Code review encouraged. Though I really only changed one thing.
