### PR TITLE
Adds .env to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ node_modules/
 docs/_dist
 coverage.html
 .cover*
+
+.env


### PR DESCRIPTION
For those of us using Heroku I think this should be added by default
