### PR TITLE
Exposes session key, session store, and session cookie parser

### DIFF
--- a/index.js
+++ b/index.js
@@ -510,6 +510,7 @@ Keystone.prototype.mount = function(mountPath, parentApp, events) {
 	}
 	
 	if (this.get('env') !== 'production') {
+		app.set('view cache', this.get('view caching off') === undefined ? true : this.get('view caching off'));
 		app.locals.pretty = true;
 	}
 	


### PR DESCRIPTION
This allows the use of session.socket.io which matches a socket.io connection with a corresponding express session.

There is no dependency on any specific implementations/versions of either express or socket.io.

A simple example using session.socket.io with keystone:

keystone.start(
{
  onHttpServerCreated: function() 
  {
    keystone.app.io = require('socket.io').listen(keystone.httpServer);
    keystone.app.sessionsocketio = new require('session.socket.io')(keystone.app.io, keystone.app.sessionOpts.store, keystone.app.sessionOpts.cookieParser, keystone.app.sessionOpts.key);
    keystone.app.sessionsocketio.on('connection', function (err, socket, session) {
      socket.emit('alert', { message: 'socket.io is connected to session: ' + session });
    });
  }
});
