### PR TITLE
S3 file - added the possibility to specify a protocol for the file url

### DIFF
--- a/lib/fieldTypes/s3file.js
+++ b/lib/fieldTypes/s3file.js
@@ -253,7 +253,7 @@ s3file.prototype.uploadFile = function(item, file, update, callback) {
 			if (err) return callback(err);
 
 			var protocol = (field.s3config.protocol && field.s3config.protocol + ':') || '',
-				url = res.req.url.replace(/^https?:/, protocol);
+				url = res.req.url.replace(/^https?:/i, protocol);
 
 			var fileData = {
 				filename: name,


### PR DESCRIPTION
By default it will remain 'https', but if you specify protocol: 'http' in your keystone 's3 config', uploaded files will have their urls saved as plain http in the backend. The reason for this is that there are cases where you don't care about SSL and just want more speed (i.e. images).
