### PR TITLE
enabled errorMessage option at UpdateHandler.process

### DIFF
--- a/lib/updateHandler.js
+++ b/lib/updateHandler.js
@@ -151,7 +151,7 @@ UpdateHandler.prototype.process = function(data, options, callback) {
 			if (options.flashErrors) {
 				this.req.flash('error', {
 					type: 'ValidationError',
-					title: this.options.errorMessage,
+					title: options.errorMessage,
 					list: _.pluck(validationErrors, 'message')
 				});
 			}
@@ -176,7 +176,7 @@ UpdateHandler.prototype.process = function(data, options, callback) {
 					if (options.flashErrors) {
 						this.req.flash('error', {
 							type: 'ValidationError',
-							title: this.options.errorMessage,
+							title: options.errorMessage,
 							list: _.pluck(err.errors, 'message')
 						});
 					}


### PR DESCRIPTION
Options passed to the process function are stored to the local options object.

Note that line 116 already has: options.errorMessage = options.errorMessage || this.options.errorMessage;
so, the flash message title defaults to a sane value just fine if the errorMessage option is not passed.
