### PR TITLE
autokey pushes unique-ness down to mongoose schema

### DIFF
--- a/lib/schemaPlugins.js
+++ b/lib/schemaPlugins.js
@@ -58,7 +58,7 @@ exports.autokey = function() {
 
 	def[autokey.path] = {
 		type: String,
-		index: { unique: true }
+		index: { unique: autokey.unique !== undefined ? autokey.unique : true }
 	};
 
 	this.schema.add(def);


### PR DESCRIPTION
I found List's with non-unique autokeys were failing with mongodb duplicate key errors; E11000. 

This small change pushes the autokey { unique } property into the mongoose schema and corrects this problem.
