### PR TITLE
adding support for replica set and authentication

### DIFF
--- a/lib/core/mount.js
+++ b/lib/core/mount.js
@@ -481,15 +481,15 @@ exports = module.exports = function mount(mountPath, parentApp, events) {
 
         var credentials = (replicaData.username && replicaData.password) ? replicaData.username +":"+replicaData.password+"@" : '';
 
-        replicaData.servers.forEach(function (server) {
-            replica += "mongodb://"+credentials+server["host"]+":"+server["port"]+"/"+replicaData.database+",";
+        replicaData.db.servers.forEach(function (server) {
+            replica += "mongodb://"+credentials+server["host"]+":"+server["port"]+"/"+replicaData.db.name+",";
         });
 
         var options = {
             auth: { authSource: replicaData.authSource },
             replset: {
-                rs_name: replicaData.rs_name,
-                readPreference: replicaData.readPreference
+                rs_name: replicaData.db.replicaSetOptions.rs_name,
+                readPreference: replicaData.db.replicaSetOptions.readPreference
             }
         };
 


### PR DESCRIPTION
This adds support for using a replica set for the mongoose connection.

In order to use it you need to specify the following options to keystone:

```
"mongo replica set":{
        "username": "your-user-name",
        "password": "your-password",
        "authSource": "your authentication source database (optional)",
        "database": "your db name",
        "rs_name": "your replica set name (optional)",
        "readPreference": "your read preference (optional)",
        "servers": [
            {
                "host": "server01.com",
                "port": 27017
            },
            {
                "host": "server02.com",
                "port": 27017
            },
            {
                "host": "server03.com",
                "port": 27017
            }
        ]
  }
```
