### PR TITLE
Fixing cloudinary issues

### DIFF
--- a/lib/fieldTypes/cloudinaryimage.js
+++ b/lib/fieldTypes/cloudinaryimage.js
@@ -320,6 +320,9 @@ cloudinaryimage.prototype.getRequestHandler = function(item, req, paths, callbac
 			if (keystone.get('env') != 'production')
 				uploadOptions.tags.push(tp + 'dev');
 
+			if (item[field.path] && item[field.path].exists)
+				field.apply(item, 'reset');
+
 			cloudinary.uploader.upload(req.files[paths.upload].path, function(result) {
 				if (result.error) {
 					callback(result.error);


### PR DESCRIPTION
This intends to fix two issues I've encountered when using Cloudinary with Keystone.
1. Whenever I clicked a "Remove Image" link on an item the field is cleared but the image is not deleted from my Cloudinary account, leaving orphan images.
2. Whenever I replace an image the existing image is never deleted from my Cloudinary account, also leaving orphan images.
