### PR TITLE
Adding the ability to specify a field to use as the CloudinaryImage public_id

### DIFF
--- a/lib/fieldTypes/cloudinaryimage.js
+++ b/lib/fieldTypes/cloudinaryimage.js
@@ -319,6 +319,10 @@ cloudinaryimage.prototype.getRequestHandler = function(item, req, paths, callbac
 			if (keystone.get('env') != 'production')
 				uploadOptions.tags.push(tp + 'dev');
 
+			if (field.options.publicID)
+				if (item[field.options.publicID])
+					uploadOptions.public_id = item[field.options.publicID];
+
 			cloudinary.uploader.upload(req.files[paths.upload].path, function(result) {
 				if (result.error) {
 					callback(result.error);


### PR DESCRIPTION
Cloudinary has the ability to specify a public ID for uploaded images/files.

I propose adding a field option to the CloudinaryImage field type called `publicID` that will contain the name of a field to be used as the public_id. The option is ignored if the specified field does not exist.

Here's an example:

```
List.add({
    slug: { type: Types.Key },
    photo: { type: Types.CloudinaryImage, publicID: 'slug' }
});
```
