### PR TITLE
Adding the ability to specify a folder for a CloudinaryImage

### DIFF
--- a/lib/fieldTypes/cloudinaryimage.js
+++ b/lib/fieldTypes/cloudinaryimage.js
@@ -304,7 +304,7 @@ cloudinaryimage.prototype.getRequestHandler = function(item, req, paths, callbac
 
 		if (req.files && req.files[paths.upload] && req.files[paths.upload].size) {
 
-			var tp = keystone.get('cloudinary prefix') || '';
+			var tp = prefix = keystone.get('cloudinary prefix') || '';
 
 			if (tp.length)
 				tp += '_';
@@ -312,6 +312,17 @@ cloudinaryimage.prototype.getRequestHandler = function(item, req, paths, callbac
 			var uploadOptions = {
 				tags: [tp + field.list.path + '_' + field.path, tp + field.list.path + '_' + field.path + '_' + item.id]
 			};
+
+			if (keystone.get('cloudinary folders') === true) {
+				if (field.options.folder)
+					uploadOptions.folder = field.options.folder;
+				else {
+					var folderList = prefix.length ? [prefix] : [];
+					folderList.push(field.list.path);
+					folderList.push(field.path);
+					uploadOptions.folder = folderList.join('/');					
+				}
+			}
 
 			if (keystone.get('cloudinary prefix'))
 				uploadOptions.tags.push(keystone.get('cloudinary prefix'));


### PR DESCRIPTION
Cloudinary has the ability to specify a folder to organize uploaded images. To enable the use of Cloudinary folders I added a Keystone option called `cloudinary folders` that should be set to `true`.

```
Keystone.init({
    ...
    'cloudinary folders': true
    ...
)};
```

or

```
Keystone.set('cloudinary folders', true);
```

A path per CloudinaryImage field can be specified using the `folder` option.

```
List.add({
    ...
    photo: { type: Types.CloudinaryImage, folder: 'path/to/image' },
    ....
});
```

Otherwise default folder path will be generated from the `cloudinary prefix`, the `list path` and `field path`. 

```
prefix/list/field
```

or

```
list/field
```
