### PR TITLE
adding cloudinary image replace on upload option

### DIFF
--- a/lib/fieldTypes/cloudinaryimage.js
+++ b/lib/fieldTypes/cloudinaryimage.js
@@ -340,6 +340,12 @@ cloudinaryimage.prototype.getRequestHandler = function(item, req, paths, callbac
 				}
 			}
 
+			if (field.options.uploadReplace) {
+				var image = item.get(field.path);
+				if (image && image.exists)
+					field.apply(item, 'delete');
+			}
+
 			cloudinary.uploader.upload(req.files[paths.upload].path, function(result) {
 				if (result.error) {
 					callback(result.error);


### PR DESCRIPTION
As per JW's suggestion, I made the CloudinaryImage "replace on upload" feature a field level option.

Setting `uploadReplace` to `true` removes an existing image (if one exists). Setting the option to `false` (or not setting it at all) results in the default behavior.

```
 List.add({
    ...
    photo: { type: Types.CloudinaryImage, uploadReplace: true },
    ...
}
```
