### PR TITLE
Fixing initial sortOrder value on sortable List

### DIFF
--- a/lib/schemaPlugins.js
+++ b/lib/schemaPlugins.js
@@ -24,7 +24,7 @@ exports.sortable = function() {
 		var item = this;
 
 		list.model.findOne().sort('-sortOrder').exec(function(err, max) {
-			item.sortOrder = (max && max.count) ? max.count + 1 : 1;
+			item.sortOrder = (max && max.sortOrder) ? max.sortOrder + 1 : 1;
 			next();
 		});
 


### PR DESCRIPTION
When adding a document to a `sortable` list I always expected the new document to be the last on the list, however that wasn't always the case. I decided to inspect the database immediately after adding a series of documents to a `sortable` list and noticed that they all had a `sortOrder` value of `1`.

I checked the `sortable()` function exported by `lib\schemaPlugins.js` and noticed that `max.count` was used  to determine the initial `sortOrder` value. Not knowing what the `.count` property was, I looked through 
Keystone to see if it had been added to the `List.schema` at some point (as a key/value pair or a virtual), but I wasn't able to find anything (I hope I didn't miss it).

I decided then to use `max.sortOrder` instead of `max.count` to determine the document's initial `sortOrder` value. This seems logical to me, but again I may have missed something in the Keystone code. (My apologies if I did.)

At one point I added code to calculate the initial `sortOrder` value differently when the `sortable` List included a `sortContext` (to keep all the `sortOrder` values consecutive from 1 to n within the scope of the `sortContext`). After giving it some thought I realized it would be an unnecessary overhead, since the `sortContext` are ordered (which is the desired result), even if not consecutive.
