### PR TITLE
Enhancing the implementation of relationship filters in the UI

### DIFF
--- a/public/js/views/item.js
+++ b/public/js/views/item.js
@@ -198,43 +198,6 @@ jQuery(function($) {
 		
 	});
 	
-	$('.field.type-relationship input[data-ref-filters]').each(function() {
-		
-		var $input = $(this),
-			$field = $input.closest('.field'),
-			data = $input.data(),
-			depChanged = false;
-		
-		_.each(data.refFilters, function(value, key) {
-			
-			if (value.substr(0,1) != ':') {
-				return;
-			}
-			
-			var $related = $('#field_' + value.substr(1)),
-				relatedData = $related.data();
-			
-			var trigger = function(msg) {
-				depChanged = true;
-				$field.find('.field-ui').hide();
-				$field.find('.field-message').append('<span>' + msg + '</span>').show();
-				$input.val('');
-			}
-			
-			if (!$related.val() && !depChanged) {
-				trigger('Please select a ' + relatedData.refSingular + ' and save before selecting a ' + data.refSingular + '.');
-			} else {
-				$related.on('change.dependency.' + $input.attr('id'), function(e) {
-					if (!depChanged) {
-						trigger(relatedData.refSingular + ' has changed. Please save to select a ' + data.refSingular + '.');
-					}
-				});
-			}
-			
-		});
-		
-	});
-	
 	$('.btn-change-password').click(function(e) {
 		
 		var $field = $(this).closest('.field');

--- a/routes/api/list.js
+++ b/routes/api/list.js
@@ -74,14 +74,11 @@ exports = module.exports = function(req, res) {
 					return doQuery();
 				}
 
-				srcList.model.findById(req.query.item, function(err, item) {
-
-					if (err) return sendError('database error', err);
-
-					field.addFilters(query, item);
-					return doQuery();
-
+				_.each(req.query.filters, function(value, key) {
+					query.where(key).equals(value ? value : null);
+					count.where(key).equals(value ? value : null);
 				});
+				return doQuery();
 
 			} else {
 				return doQuery();

--- a/templates/fields/relationship/form.jade
+++ b/templates/fields/relationship/form.jade
@@ -24,7 +24,7 @@ else
 					data-ref-path=refList.path,
 					data-ref-singular=refList.singular,
 					data-ref-plural=refList.plural).ui-select2-ref
-				if !field.many && item.get(field.path)
-					a(href='/keystone/' + refList.path + '/' + item.get(field.path), style='margin-left: 10px;').btn.btn-link.btn-goto-linked-item view #{refList.singular.toLowerCase()}
+				if !field.many
+					a(href='/keystone/' + refList.path + '/' + item.get(field.path), style='margin-left: 10px;' + (!item.get(field.path) ? 'display: none' : '')).btn.btn-link.btn-goto-linked-item view #{refList.singular.toLowerCase()}
 			if field.note
 				.field-note!= field.note

--- a/templates/fields/relationship/initial.jade
+++ b/templates/fields/relationship/initial.jade
@@ -5,6 +5,7 @@ else
 	.field.type-relationship
 		label.field-label= field.label
 		.field-ui
+			.field-message
 			input(type='hidden',
 				name=field.path,
 				id='field_' + field.path,


### PR DESCRIPTION
This is my implementation of relationship filters in the UI. Based on your comments in #10, it seems like you've had this on the radar for a while now. In the interest of being proactive and saving time, I decided to submit this pull request now, instead of waiting for your 'go signal' in response to my comments in #10. This way you can just evaluated my proposed changes now and tell me your thoughts.

This is a breakdown of what I did.

`views/item.js`
- Removed the code that handles `.field.type-relationship input[data-ref-filters]` elements and move most of it to `common/ui.js`, because I wanted the same look/feel in both the `initial.jade` view and the `form.jade` view.

`common/ui.js`
- Gathered filters from `refFilters` and fetched the related field's current value (from the UI)
- Sent the filters/values to autocomplete API
- Showed/hid the `.btn-goto-linked-item` element depending on whether or not a value was selected, and updated the `href` attribute to reflect the selected value
- Added to code to handle `.field.type-relationship input[data-ref-filters]`elements with a few modifications. 
  - The field is now cleared (not hidden) when its dependency changes.
  - The `field-message` is now correctly shown/hidden when the field's dependency is empty (this is now true for both the `initial.jade` view and the `form.jade` view).

`api/list.js`
- Replaced the code that looked up the saved item to add the filter to the query, with code that processes the filters/values sent from `common/ui.js` and added them to both the `query` query (pardon the redundancy) and the `count` query (so the Select2 in the UI gets the correct count for pagination).

`relationship/initial.jade`
- Added a `.field-message` div to mirror then one in `relationship/form.jade`. Again, I wanted to maintain the same look/feel across the UI.

`relationship/form.jade`
- Added code to initially hide the `.btn-link.btn-goto-linked-item` element when the field is empty.

That's it! As I mentioned in my previous comment, I've been using this implementation for a while without incident. I understand it deviates considerably from the current implementation, and you therefore might be hesitant to merge at this point in time. However, I decided to submit it anyway because I believe Keystone users would not only appreciate but benefit from this enhancement.

Let me know your thoughts and a usual feel free to tweak away.
