### PR TITLE
Log any errors found with the createItems during the updates process.

### DIFF
--- a/lib/core/createItems.js
+++ b/lib/core/createItems.js
@@ -251,9 +251,13 @@ exports = module.exports = function createItems(data, ops, callback) {
 		}
 		
 	], function(err) {
-		
-		if (err) return callback && callback(err);
-		
+
+		if (err) {
+			console.error(err);
+			console.trace(err.stack);
+			return callback && callback(err);
+		}
+
 		var msg = '\nSuccessfully created:\n';
 		_.each(stats, function(list) {
 			msg += '\n*   ' + utils.plural(list.created, '* ' + list.singular, '* ' + list.plural);


### PR DESCRIPTION
It was painful trying to figure out what went wrong during an updates process if errors occurred during the createItems processing.  This change logs any errors found during createItems to speed up the troubleshooting process.
