### PR TITLE
Fixed wrong default value for select in initial view

### DIFF
--- a/templates/fields/select/initial.jade
+++ b/templates/fields/select/initial.jade
@@ -5,6 +5,6 @@
 			if field.emptyOption
 				option(value='')
 			each opt in field.ops
-				option(value=opt.value, selected=(item[field.path] == opt.value))= opt.label
+				option(value=opt.value, selected=(field.options.default == opt.value))= opt.label
 		if field.note
 			.field-note!= field.note

--- a/templates/views/list.jade
+++ b/templates/views/list.jade
@@ -291,7 +291,7 @@ block content
 									.filter-input.filter-input-md: select(name='value')
 										option(value='')
 										each op in field.ops
-											option(value=op.value, selected=ops.value == op.value)= op.label
+											option(value=op.value, selected=field.options.default == op.value)= op.label
 								
 								//- Boolean
 								if field.type == 'boolean'


### PR DESCRIPTION
In both cases, the item[field.path] and ops.value were undefined. Fixed by replacing them with the .default options from field.

Fixes #453
