### PR TITLE
Fix for issue #398, AdminUI: Recalculate total after delete

### DIFF
--- a/lib/list.js
+++ b/lib/list.js
@@ -1058,6 +1058,38 @@ List.prototype.getUniqueValue = function(path, generator, limit, callback) {
 
 };
 
+/**
+ * Generate page array for pagination
+ *
+ * @param {Number} the maximum number pages to display in the pagination
+ * @param {Object} page options
+ * @api public
+ */
+List.prototype.getPages = function(options, maxPages) {
+		var surround = Math.floor(maxPages / 2),
+			firstPage = maxPages ? Math.max(1, options.currentPage - surround) : 1,
+			padRight = Math.max(((options.currentPage - surround) - 1) * -1, 0),
+			lastPage = maxPages ? Math.min(options.totalPages, options.currentPage + surround + padRight) : options.totalPages,
+			padLeft = Math.max(((options.currentPage + surround) - lastPage), 0);
+
+		options.pages = [];
+
+		firstPage = Math.max(Math.min(firstPage, firstPage - padLeft), 1);
+
+		for (var i = firstPage; i <= lastPage; i++) {
+			options.pages.push(i);
+		}
+
+		if (firstPage !== 1) {
+			options.pages.shift();
+			options.pages.unshift('...');
+		}
+
+		if (lastPage !== Number(options.totalPages)) {
+			options.pages.pop();
+			options.pages.push('...');
+		}
+}
 
 /**
  * Gets a special Query object that will paginate documents in the list
@@ -1079,7 +1111,7 @@ List.prototype.getUniqueValue = function(path, generator, limit, callback) {
 
 List.prototype.paginate = function(options, callback) {
 
-	var model = this.model;
+	var list = this, model = this.model;
 
 	options = options || {};
 
@@ -1093,6 +1125,8 @@ List.prototype.paginate = function(options, callback) {
 		resultsPerPage = Number(options.perPage) || 50,
 		maxPages = Number(options.maxPages) || 10,
 		skip = (currentPage - 1) * resultsPerPage;
+
+	list.pagination = { maxPages: maxPages };
 
 	// as of mongoose 3.7.x, we need to defer sorting and field selection
 	// until after the count has been executed
@@ -1142,28 +1176,7 @@ List.prototype.paginate = function(options, callback) {
 					last: skip + results.length
 				};
 
-				var surround = Math.floor(maxPages / 2);
-				var firstPage = maxPages ? Math.max(1, currentPage - surround) : 1;
-				var padRight = Math.max(((currentPage - surround) - 1) * -1, 0);
-
-				var lastPage = maxPages ? Math.min(totalPages, currentPage + surround + padRight) : totalPages;
-
-				var padLeft = Math.max(((currentPage + surround) - lastPage), 0);
-				firstPage = Math.max(Math.min(firstPage, firstPage - padLeft), 1);
-
-				for (var i = firstPage; i <= lastPage; i++) {
-					rtn.pages.push(i);
-				}
-
-				if (firstPage !== 1) {
-					rtn.pages.shift();
-					rtn.pages.unshift('...');
-				}
-
-				if (lastPage !== totalPages) {
-					rtn.pages.pop();
-					rtn.pages.push('...');
-				}
+				list.getPages(rtn, maxPages);
 
 				callback(err, rtn);
 

--- a/templates/mixins/pagination.jade
+++ b/templates/mixins/pagination.jade
@@ -1,0 +1,5 @@
+mixin pagination(items)
+  .count Showing #{items.first} to #{items.last} of #{items.total}
+  ul.pagination: each p, i in items.pages
+    li(class=items.currentPage == p ? 'active' : null)
+      a(href=(p == '...' ? link_to({page: (i ? items.totalPages : 1)}) : link_to({page: p})))= p

--- a/templates/mixins/rows.jade
+++ b/templates/mixins/rows.jade
@@ -1,0 +1,11 @@
+include columns
+
+mixin row(list, colums, item)
+  tr(id=item.id)
+    if !list.get('nodelete')
+      td.control: a(href='/keystone/' + list.path + '?delete=' + item.id + csrf_query).control-delete
+    if sortable
+      td.control: a(href=js).control-sort
+    each col, i in columns
+      td
+        +column(list, col, item)

--- a/templates/partials/pagination.jade
+++ b/templates/partials/pagination.jade
@@ -1,0 +1,3 @@
+include ../mixins/pagination.jade
+
++pagination(items)

--- a/templates/partials/row.jade
+++ b/templates/partials/row.jade
@@ -1,0 +1,3 @@
+include ../mixins/rows.jade
+
++row(list, colums, item)

--- a/templates/views/list.jade
+++ b/templates/views/list.jade
@@ -1,6 +1,7 @@
 extends ../layout/base
 
-include ../mixins/columns
+include ../mixins/rows
+include ../mixins/pagination
 
 block css
 	if list.fieldTypes.markdown
@@ -21,8 +22,14 @@ block js
 	script(src='/keystone/js/lib/browserified/querystring.js')
 	script(src='/keystone/js/lib/browserified/queryfilter.js')
 	script.
-		Keystone.list = { path: "#{list.path}", label: "#{list.label}", singular: "#{list.singular}", plural: "#{list.plural}", cols: !{JSON.stringify(colPaths)} };
+		Keystone.list = { path: "#{list.path}", label: "#{list.label}", singular: "#{list.singular}", plural: "#{list.plural}", cols: !{JSON.stringify(colPaths)}, perPage: !{ Number(list.perPage) || 50 } };
 		Keystone.wysiwyg = { options: !{JSON.stringify(wysiwygOptions)} };
+		Keystone.items = !{ JSON.stringify(items) };
+		Keystone.search = "#{search}";
+		Keystone.filters = !{ JSON.stringify(filters) };
+		Keystone.sort = "#{sort.by}";
+		Keystone.query = "#{query}";
+		Keystone.csrf_query = "!{csrf_query}";
 			
 block content
 	//-
@@ -71,67 +78,69 @@ block content
 	.page-header.list-header(class=!items.total && !search && !xFilters ? 'empty-list' : '')
 		h1
 			if items.total
-				span= utils.plural(items.total, '* ' + list.singular, '* ' + list.plural)
+				span.items-total= utils.plural(items.total, '* ' + list.singular, '* ' + list.plural)
 			else
-				span No #{list.plural.toLowerCase()} found
+				span.items-total No #{list.plural.toLowerCase()} found
 					= search || xFilters ? '' : '.'
-			if search
-				span.text-muted  matching 
-				span=search
-				if xFilters
-					span.text-muted  and
-					span= utils.plural(xFilters, ' * other filter')
-			else if xFilters
-				span.text-muted  matching 
-				span= utils.plural(xFilters, ' * filter')
+
+			.search-sort(style='display:inline-block')
+				if search
+					span.text-muted  matching 
+					span=search
+					if xFilters
+						span.text-muted  and
+						span= utils.plural(xFilters, ' * other filter')
+				else if xFilters
+					span.text-muted  matching 
+					span= utils.plural(xFilters, ' * filter')
 			
-			//- Sort
-			if items.results.length
-				if sort.by
-					span.text-muted  ordered by&nbsp;
-				else
-					span.text-muted &mdash;
-				span.dropdown.list-sort-dropdown
-					a(href=js, data-toggle='dropdown').dropdown-toggle
-						if sort.label
-							=  sort.label.toLowerCase() + ' '
-							if sort.inv
-								|  (descending)
-						else
-							| sort by
-						b.caret
-					ul.dropdown-menu
-						if list.get('sortable')
-							if sort.by == 'sortOrder'
-								li: a(href=link_to({sort: '-sortOrder'}))
-									span(class='fieldicon fieldicon-sort')
-									span Display Order (inverted)
-							else if sort.by == '-sortOrder'
-								li: a(href=link_to({sort: 'sortOrder'}))
-									span(class='fieldicon fieldicon-sort')
-									span Display Order (normal)
+				//- Sort
+				if items.results.length
+					if sort.by
+						span.text-muted  ordered by&nbsp;
+					else
+						span.text-muted &mdash;
+					span.dropdown.list-sort-dropdown
+						a(href=js, data-toggle='dropdown').dropdown-toggle
+							if sort.label
+								=  sort.label.toLowerCase() + ' '
+								if sort.inv
+									|  (descending)
 							else
-								li: a(href=link_to({sort: 'sortOrder'}))
-									span(class='fieldicon fieldicon-sort')
-									span Display Order
-						each el in list.uiElements
-							if el.type == 'heading'
-								li.dropdown-header= el.heading
-							else if el.type == 'field'
-								if el.field.type != 'relationship' && !el.field.nosort && !el.field.hidden
-									if sort.field && sort.field.path == el.field.path
-										if sort.inv
+								| sort by
+							b.caret
+						ul.dropdown-menu
+							if list.get('sortable')
+								if sort.by == 'sortOrder'
+									li: a(href=link_to({sort: '-sortOrder'}))
+										span(class='fieldicon fieldicon-sort')
+										span Display Order (inverted)
+								else if sort.by == '-sortOrder'
+									li: a(href=link_to({sort: 'sortOrder'}))
+										span(class='fieldicon fieldicon-sort')
+										span Display Order (normal)
+								else
+									li: a(href=link_to({sort: 'sortOrder'}))
+										span(class='fieldicon fieldicon-sort')
+										span Display Order
+							each el in list.uiElements
+								if el.type == 'heading'
+									li.dropdown-header= el.heading
+								else if el.type == 'field'
+									if el.field.type != 'relationship' && !el.field.nosort && !el.field.hidden
+										if sort.field && sort.field.path == el.field.path
+											if sort.inv
+												li: a(href=link_to({ sort: el.field.path }))
+													span(class='fieldicon fieldicon-' + el.field.type)
+													span= el.field.label + ' (ascending)'
+											else
+												li: a(href=link_to({ sort: '-' + el.field.path }))
+													span(class='fieldicon fieldicon-' + el.field.type)
+													span= el.field.label + ' (descending)'
+										else
 											li: a(href=link_to({ sort: el.field.path }))
 												span(class='fieldicon fieldicon-' + el.field.type)
-												span= el.field.label + ' (ascending)'
-										else
-											li: a(href=link_to({ sort: '-' + el.field.path }))
-												span(class='fieldicon fieldicon-' + el.field.type)
-												span= el.field.label + ' (descending)'
-									else
-										li: a(href=link_to({ sort: el.field.path }))
-											span(class='fieldicon fieldicon-' + el.field.type)
-											span= el.field.label
+												span= el.field.label
 		
 		
 		//-
@@ -370,10 +379,7 @@ block content
 		
 		.list-pagination
 			if items.totalPages > 1
-				.count Showing #{items.first} to #{items.last} of #{numeral(items.total).format('1,1')}
-				ul.pagination: each p, i in items.pages
-					li(class=items.currentPage == p ? 'active' : null)
-						a(href=(p == '...' ? link_to({page: (i ? items.totalPages : 1)}) : link_to({page: p})))= p
+				+pagination(items)
 			else
 				.count Showing #{utils.plural(items.total, '* ' + list.singular, '* ' + list.plural)}
 		
@@ -409,19 +415,9 @@ block content
 								= col.label
 			tbody
 				each item in items.results
-					tr(id=item.id)
-						if !list.get('nodelete')
-							td.control: a(href='/keystone/' + list.path + '?delete=' + item.id + csrf_query).control-delete
-						if sortable
-							td.control: a(href=js).control-sort
-						each col, i in columns
-							td
-								+column(list, col, item)
+					+row(list, colums, item)
 								
 		if items.totalPages > 1
 			.list-pagination
-				.count Showing #{items.first} to #{items.last} of #{numeral(items.total).format('1,1')}
-				ul.pagination: each p, i in items.pages
-					li(class=items.currentPage == p ? 'active' : null)
-						a(href=(p == '...' ? link_to({page: (i ? items.totalPages : 1)}) : link_to({page: p})))= p
+				+pagination(items)
 	


### PR DESCRIPTION
Not sure if anyone was working #398, but it had been bugging me for a while.

This PR makes the following behavioral changes:
1. Deleting the last item removes the `item-list` table, `pagination` and `header` and displays "No 'list-name' found"
2. Deleting an item from the last page (or the first and only page) updates `header` and `pagination`
3. Deleting an item when not on the last page fetches the next item (to fill the max with `maxItems`) and updates the `header` and `pagination`
4. Deleting the last remaining item on the last page (when there are multiple pages) redirects to the previous page

I also refactored some code to make it reusable.
1. The `getPages` method in `lib/list.js` (which I reuse to updated `pagination`)
2. A `rows` mixin (which I use reuse after fetching the next item to fill a page)
3. A `pagination` mixin (which I also use to update `pagination`)
