### PR TITLE
fixing default/alt behavior when deleting/removing cloudinary images

### DIFF
--- a/public/js/common/ui-cloudinaryimage.js
+++ b/public/js/common/ui-cloudinaryimage.js
@@ -87,12 +87,12 @@ jQuery(function($) {
 		$deleteBtn.click(function(e) {
 			e.preventDefault();
 			// Action
-			if (e.altKey && $deleteBtn.data('default-action') === 'remove') {
-				$action.val('delete');
-				action = 'delete';
+			if (e.altKey) {
+				$action.val($deleteBtn.data('alt-action'));
+				action = $deleteBtn.data('alt-action') === 'delete' ? 'delete' : 'remove';
 			} else {
-				$action.val('reset');
-				action = 'remove';
+				$action.val($deleteBtn.data('default-action'));
+				action = $deleteBtn.data('default-action') === 'delete' ? 'delete' : 'remove';
 			}
 			// Details
 			$imageValues.hide();

--- a/templates/fields/cloudinaryimage/form.jade
+++ b/templates/fields/cloudinaryimage/form.jade
@@ -36,9 +36,9 @@
 				div.pull-left
 					a(href=js).btn.btn-default.btn-upload-image= (hasImage ? 'Change' : 'Upload') + ' Image'
 					if field.options.autoCleanup
-						a(href=js, data-alt-text='Remove Image', data-default-action='delete', style=(hasImage ? '' : 'display: none;')).btn.btn-link.btn-cancel.btn-delete-image Delete Image
+						a(href=js, data-alt-text='Remove Image', data-default-action='delete', data-alt-action='reset', style=(hasImage ? '' : 'display: none;')).btn.btn-link.btn-cancel.btn-delete-image Delete Image
 					else
-						a(href=js, data-alt-text='Delete Image', data-default-action='reset', style=(hasImage ? '' : 'display: none;')).btn.btn-link.btn-cancel.btn-delete-image Remove Image
+						a(href=js, data-alt-text='Delete Image', data-default-action='reset', data-alt-action='delete', style=(hasImage ? '' : 'display: none;')).btn.btn-link.btn-cancel.btn-delete-image Remove Image
 					a(href=js, style='display: none;').btn.btn-link.btn-cancel.btn-cancel-image Cancel Upload
 					a(href=js, style='display: none;').btn.btn-link.btn-cancel.btn-undo-image Undo Remove
 		if field.note


### PR DESCRIPTION
Delete/remove actions on `CloudinaryImage` fields were not behaving as expected.

The current logic on performs a `delete` when the `ALT` key is pressed and the default action is `remove`. It, however, does not account for a scenario when the default action is `delete` and the `ALT` key is not pressed.
