### PR TITLE
Fixing issue #492 - upload failed, invalid signature

### DIFF
--- a/lib/fieldTypes/cloudinaryimage.js
+++ b/lib/fieldTypes/cloudinaryimage.js
@@ -356,9 +356,12 @@ cloudinaryimage.prototype.getRequestHandler = function(item, req, paths, callbac
 			}
 
 			var uploadOptions = {
-				tags: [tp + field.list.path + '_' + field.path, tp + field.list.path + '_' + field.path + '_' + item.id],
-				folder: item.get(field.paths.folder)
+				tags: [tp + field.list.path + '_' + field.path, tp + field.list.path + '_' + field.path + '_' + item.id]
 			};
+
+			if (item.get(field.paths.folder)) {
+				uploadOptions.folder = item.get(field.paths.folder);
+			}
 
 			if (keystone.get('cloudinary prefix')) {
 				uploadOptions.tags.push(keystone.get('cloudinary prefix'));


### PR DESCRIPTION
Identified a bug when `cloudinary folder` feature is turned off. The Cloudinary API generates an invalid signature when `folder` is set to `null` in `uploadOptions`. Fixed the issue by excluding `folder` from `uploadOptions` when `item.get('field.paths.folder')` returns `null`.

Sorry ... my bad!
