### PR TITLE
You specify error code to send on res.apiError ( added as a parameter  )

### DIFF
--- a/lib/middleware/initAPI.js
+++ b/lib/middleware/initAPI.js
@@ -27,7 +27,7 @@ exports = module.exports = function(keystone) {
 				res.json(status);
 		};
 
-		res.apiError = function(key, err, msg) {
+		res.apiError = function(key, err, msg, code) {
 			msg = msg || 'Error';
 			key = key || 'unknown error';
 			msg += ' (' + key + ')';
@@ -37,7 +37,7 @@ exports = module.exports = function(keystone) {
 					console.log(err);
 				}
 			}
-			res.status(500);
+			res.status(code || 500);
 			res.apiResponse({ error: key || 'error', detail: err });
 		};
 


### PR DESCRIPTION
Add `code` parameter to res.apiError, this way you can send a different code of 500 if you want
