### PR TITLE
Adding current user available to pre/post save hooks

### DIFF
--- a/lib/updateHandler.js
+++ b/lib/updateHandler.js
@@ -166,6 +166,9 @@ UpdateHandler.prototype.process = function(data, options, callback) {
 	}.bind(this);
 
 	var saveItem = function() {
+		// Make current user available to pre/post save events
+		this.item._user = this.user;
+		
 		this.item.save(function(err) {
 			if (err) {
 				if (err.name === 'ValidationError') {


### PR DESCRIPTION
This PR makes the current user available to `pre` and `post` save hooks.

I do not alter the model per se. I simply add a `_user` property to the `item` object just before it is saved in `updateHandler`, but since `mongoose` is unaware of it's existence, it does not save it to the database. The property is temporary in nature and does not survive the current transaction.

Here's a usage example.

```
List.schema.pre('save', function(next, done) {
    console.log('current user =>', this._user);
    next();
});
```

The idea of having the current user available to `pre` and `post` save hooks was originally raised in #458 in the context of using it for audit purposes (which I addressed in #490). However, having the current user available in `pre` and `post` save hooks is also quite useful in use cases other than this, which is why I decided to submit this as a separate pull request.
