### PR TITLE
autokey: Added 'fixed' attribute to control if the value should be changed on update

### DIFF
--- a/lib/schemaPlugins.js
+++ b/lib/schemaPlugins.js
@@ -120,7 +120,8 @@ exports.autokey = function() {
 			}
 		}, this);
 
-		if (!modified && this.get(autokey.path)) {
+		// if has a value and is unmodified or fixed, don't update it
+		if ((!modified || autokey.fixed) && this.get(autokey.path)) {
 			return next();
 		}
 


### PR DESCRIPTION
Added a new option to the `autokey` plugin to control if the key should be updated on every save.

Use cases:
- A blog with posts with fixed slugs can keep original URLs even if titles change (ie: "Javascript case study (updated)").
- A fixed slug, updated on create but editable later from the Admin UI, or regenerable if value is empty.
