### PR TITLE
Remove nbsp; again

### DIFF
--- a/templates/views/list.jade
+++ b/templates/views/list.jade
@@ -97,7 +97,7 @@ block content
 				//- Sort
 				if items.results.length
 					if sort.by
-						span.text-muted  &nbsp;ordered by&nbsp;
+						span.text-muted ordered by&nbsp;
 					else
 						span.text-muted &mdash;
 					span.dropdown.list-sort-dropdown


### PR DESCRIPTION
Spaces in html... now that I added this, it shows two spaces and when I remove it again, to what I think it was before it has one space again. Hmmm, why did it even show no space in the first place...
Anyway, hope this little bug is fixed now. Maybe double check my work.

Also, I shouldn't write PRs and first thing in the morning, too easy to confuse with the extended commit messages it seems.
