### PR TITLE
Changed Today button to Now button for datetime fields.

### DIFF
--- a/public/styles/keystone/forms.less
+++ b/public/styles/keystone/forms.less
@@ -651,7 +651,7 @@ label.checkbox {
 .field-message {
 	display: none;
 	min-height: 30px;
-	
+
 	span {
 		display: inline-block;
 		background: #f9f9f9;
@@ -684,7 +684,7 @@ label.checkbox {
 	width: auto;
 }
 
-.field.type-date .btn-set-today, .field.type-datetime .btn-set-today {
+.field.type-date .btn-set-today, .field.type-datetime .btn-set-now {
 	margin-left: 10px;
 	margin-right: 10px;
 }

--- a/templates/fields/datetime/form.jade
+++ b/templates/fields/datetime/form.jade
@@ -5,7 +5,7 @@
 			.field-value= field.format(item, 'Do MMM YYYY, h:mm:ss a')
 		else
 			input(type='text', name=field.paths.date, value=field.format(item, 'YYYY-MM-DD'), placeholder='YYYY-MM-DD', autocomplete='off').form-control.ui-datepicker
-			a(href=js).btn.btn-default.btn-set-today Today
-			input(type='text', name=field.paths.time, value=field.format(item, 'h:mm:ss a'), placeholder='HH:MM:SS am/pm', autocomplete='off').form-control
+			input(type='text', name=field.paths.time, value=field.format(item, 'h:mm:ss a'), placeholder='HH:MM:SS am/pm', autocomplete='off').form-control.time
+			a(href=js).btn.btn-default.btn-set-now Now
 	if field.note
 		.col-sm-9.col-md-10.col-sm-offset-3.col-md-offset-2: .field-note!= field.note


### PR DESCRIPTION
Turns out that our clients want a Datetime for `publishedDate` and a `Now` button (which sets the date as well as the time) make much more sense.

EDIT: I did found a minor bug, not sure yet about the best way to handle this. Because it is JS, it inserts the date with the user's time-zone, but then on the Server it doesn't seem to convert it correctly.
So in my case, I am in `GMT+0100 (BST)` and the Server is in `GMT+0000 (UTC)`.

So in the frontend the timestamp would be `Thu Aug 14 2014 13:32:23 GMT+0100 (BST)`
and in the backend `Thu Aug 14 2014 12:32:23 GMT+0000 (UTC)`.
But currently it just seems to get saved as `Thu Aug 14 2014 13:32:23 GMT+0000 (UTC)`
