### PR TITLE
Sort order consistent and starting from 0

### DIFF
--- a/lib/schemaPlugins.js
+++ b/lib/schemaPlugins.js
@@ -17,14 +17,14 @@ exports.sortable = function() {
 
 	this.schema.pre('save', function(next) {
 
-		if (this.sortOrder) {
+		if (typeof this.sortOrder === 'number') {
 			return next();
 		}
 
 		var item = this;
 
 		list.model.findOne().sort('-sortOrder').exec(function(err, max) {
-			item.sortOrder = (max && max.sortOrder) ? max.sortOrder + 1 : 1;
+			item.sortOrder = (max && max.sortOrder) ? max.sortOrder + 1 : 0;
 			next();
 		});
 


### PR DESCRIPTION
The Admin UI sorts the elements from index 0; instead, the middleware expects 1+ indexes. So, if you update the first item in the list, the lazy `if` statement changes `sortOrder` to the max + 1.
Adding a type check should fix this wrong behaviour and make the index 0 based across the board.
