### PR TITLE
Make createItems more resilient to crash exceptions

### DIFF
--- a/lib/core/createItems.js
+++ b/lib/core/createItems.js
@@ -291,7 +291,7 @@ function createItems(data, ops, callback) {
 		_.each(stats, function(list) {
 			msg += '\n*   ' + utils.plural(list.created, '* ' + list.singular, '* ' + list.plural);
 			if (list.warnings) {
-				msg += '\n    ' + list.warnings + ' warnings';
+				msg += '\n    ' + utils.plural(list.warnings, '* warning', '* warnings');
 			}
 		});
 		stats.message = msg + '\n';


### PR DESCRIPTION
The createItems function was updated to get around some problematic crash exceptions I ran into during updates.  The following is a summary of the changes:
- A Warnings counter per list was added to track warnings during the items linking phase.  
- A Warning Counter Summary dumped at the end.  The following is a sample output of the counter at the end:
  
  Successfully created:
  
  ...
  -   1 AAA
     **0 warnings**
  -   1 BBB
     **1 warnings**
    ...
- Checks where added to prevent run-time exceptions.  Instead, the exceptions are logged.  Some were harmless.
- The following is a sample generated warning:
  
  **APP-NAME: WARNING:  Invalid relationship(undefined reference list) [list: THE-LIST] [path: THE-PATH]**
- An internal writeLog function was created to centralize createItems logging.  Did this because I wanted to differentiate logging for different vhost all coming up in parallel.  As you can see in #4 above the keystone.get('name') property is prepended to the logs.

Feel free to tweak as you see fit.  It did solve my issues and provides better feedback!
