### PR TITLE
Wysiwyg mod

### DIFF
--- a/index.js
+++ b/index.js
@@ -294,9 +294,9 @@ Keystone.prototype.render = function(req, res, view, ext) {
 			additionalButtons: keystone.get('wysiwyg additional buttons') || '',
 			additionalPlugins: keystone.get('wysiwyg additional plugins') || '',
 			additionalOptions: keystone.get('wysiwyg additional options') || {},
-            overrideToolbar: keystone.get('wysiwyg override toolbar'),
-            skin: keystone.get('wysiwyg skin') || 'keystone',
-            menubar: keystone.get('wysiwyg menubar')
+			overrideToolbar: keystone.get('wysiwyg override toolbar'),
+			skin: keystone.get('wysiwyg skin') || 'keystone',
+			menubar: keystone.get('wysiwyg menubar')
 		}
 	};
 	

--- a/public/js/common/ui-wysiwyg.js
+++ b/public/js/common/ui-wysiwyg.js
@@ -5,8 +5,8 @@ jQuery(function($) {
 
 	var plugins = [ 'code', 'link' ],
 		toolbar = Keystone.wysiwyg.options.overrideToolbar ? '' : 'bold italic | alignleft aligncenter alignright | bullist numlist | outdent indent | link',
-        skin = Keystone.wysiwyg.options.skin,
-        menubar = Keystone.wysiwyg.options.menubar;
+		skin = Keystone.wysiwyg.options.skin,
+		menubar = Keystone.wysiwyg.options.menubar;
 
 	if (Keystone.wysiwyg.options.enableImages) {
 		plugins.push('image');


### PR DESCRIPTION
This will enable the `menubar` to be shown and use an alternative `skin`
keystone skin doesn't have button symbols for some additional buttons.
added options:
`'wysiwyg override toolbar'`\- override existing buttons (good for rearrangement)
`'wysiwyg menubar'`\- show the menubar
`'wysiwyg skin'`\- change skin
use example:

```
'wysiwyg override toolbar': false,
'wysiwyg menubar': true,
'wysiwyg additional buttons': 'searchreplace visualchars, charmap ltr rtl pagebreak paste, ' +
   'forecolor backcolor, emoticons media, preview print ',
'wysiwyg additional plugins': 'example, table, advlist, anchor, autolink, autosave, bbcode, charmap,    contextmenu, directionality, emoticons, fullpage, hr, media, pagebreak, paste, preview, print, searchreplace, '    + 'textcolor, visualblocks, visualchars, wordcount',
    'wysiwyg skin': 'lightgray',
```

![screen shot 2014-08-24 at 7 56 41 pm](https://cloud.githubusercontent.com/assets/1903059/4023326/fa32d952-2b86-11e4-96eb-bdfd69839002.png)
