### PR TITLE
Added an option to choose the csv delimiter on export.

### DIFF
--- a/docs/content/pages/docs/configuration.jade
+++ b/docs/content/pages/docs/configuration.jade
@@ -35,7 +35,7 @@ block content
 			a(name='options-project')
 			h3 Project Options
 			
-			p The following options control the branding and navigation of the KeystoneJS application in the Admin UI:
+			p The following options control the branding, navigation and default export settings of the KeystoneJS application in the Admin UI:
 			
 			table.table
 				col(width=210)
@@ -51,6 +51,9 @@ block content
 					td
 						p An object that specifies the navigation structure for the Admin UI. Create a key for each section that should be visible in the primary navigation. Each key's value can be a single list path (as is seen in the URL when you view a list) or an array of list paths. When an array is used, secondary navigation is rendered in the Admin UI.
 						p The nav is also used to generate the links on the Admin UI home page; any lists that are registered but not included in the <code>nav</code> will be grouped at the bottom of the screen under the 'Other' heading.
+				tr
+					td <code>csv field delimiter</code> <code class="data-type">String</code>
+					td Allow you to choose a custom field delimiter to be used for CSV export instead of the default comma.
 			
 			.code-header
 				h4 Custom Navigation Example

--- a/routes/download/list.js
+++ b/routes/download/list.js
@@ -72,7 +72,8 @@ exports = module.exports = function(req, res) {
 
 			csv().from(data).to(res.attachment(req.list.path + '-' + moment().format('YYYYMMDD-HHMMSS') + '.csv'), {
 				header: true,
-				columns: columns
+				columns: columns,
+				delimiter: keystone.get('csv field delimiter') || ','
 			});
 
 		};


### PR DESCRIPTION
Hi!
I'm leaning the system, and have encountered the need to change the CSV delimiter, so Excel (yeah only excel is weird enough to not try to detect the delimiter) can open the file correctly. 

I just made this small pull request, I would like feedback if there are better ways to do it, as I'm still trying to learn Node and Keystone. Maybe expose the whole set of options offered by node-csv? Allow per model config instead of a global config? ( but I don't think that it really make sense). I Didn't know where I should document it, so didn't add it to the doc.

Thanks!
