### PR TITLE
Fixing 'cloudinary folders' option

### DIFF
--- a/lib/fieldTypes/cloudinaryimage.js
+++ b/lib/fieldTypes/cloudinaryimage.js
@@ -360,8 +360,8 @@ cloudinaryimage.prototype.getRequestHandler = function(item, req, paths, callbac
 				tags: [tp + field.list.path + '_' + field.path, tp + field.list.path + '_' + field.path + '_' + item.id]
 			};
 
-			if (item.get(field.paths.folder)) {
-				uploadOptions.folder = item.get(field.paths.folder);
+			if (keystone.get('cloudinary folders')) {
+				uploadOptions.folder = item.get(paths.folder);
 			}
 
 			if (keystone.get('cloudinary prefix')) {


### PR DESCRIPTION
Fixed Keystone `cloudinary folders` option and CloudinaryImage `folder` option not working as I originally advertised in #456 (and as per docs submitted in PR #594).
