### PR TITLE
Fixing issue #597 regarding cloudinary caching

### DIFF
--- a/lib/fieldTypes/cloudinaryimage.js
+++ b/lib/fieldTypes/cloudinaryimage.js
@@ -146,6 +146,8 @@ cloudinaryimage.prototype.addToSchema = function() {
 			options.secure = true;
 		}
 
+		options.version = item.get(paths.version);
+
 		return cloudinary.url(item.get(paths.public_id) + '.' + item.get(paths.format), options);
 
 	};


### PR DESCRIPTION
With this fix we will still be taking advantage of Cloudinary's CDN caching. By setting the `version` option, we just ensure that we generate a URL for the latest cached version of the transformed image.
