### PR TITLE
Fixed reference to travis-ci build status image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![KeystoneJS](http://keystonejs.com/images/logo.svg)
 ===================================
 
-![Build Status](https://travis-ci.org/JedWatson/keystone.svg)
+![Build Status](https://travis-ci.org/keystonejs/keystone.svg)
 
 [KeystoneJS](http://keystonejs.com) is a powerful new Node.js content management system and web app framework built on [express](http://expressjs.com) and [mongoose](http://mongoosejs.com) that makes it easy to create sophisticated web sites and apps, and gives you a beautiful, auto-generated Admin UI.
 


### PR DESCRIPTION
Needed fixing after moving Keystone repo to the `keystonejs` org.
