### PR TITLE
Markdown editor headers buttons and customisation

### DIFF
--- a/docs/content/pages/docs/database.jade
+++ b/docs/content/pages/docs/database.jade
@@ -741,6 +741,12 @@ block content
 			pre: code.language-javascript { type: Types.Markdown }
 			.options
 				
+				h5 Options
+				p <code>toolbarOptions</code> <code class="data-type">Object</code> - allow customizations of the toolbar.
+				p <code>toolbarOptions.hiddenButtons</code> <code class="data-type">String</code> - Comma separated list of buttons to hide.
+				pre: code.language-javascript
+					| { type: Types.Markdown, toolbarOptions: { hiddenButtons: 'H1,H6,Code' } }
+
 				h5 Schema
 				p The markdown field will automatically convert markdown to html when the <code>md</code> property is changed, via a setter on the <code>md</code> path.
 				p <code>md</code> <code class="data-type">String</code> - source markdown text

--- a/lib/fieldTypes/markdown.js
+++ b/lib/fieldTypes/markdown.js
@@ -17,6 +17,7 @@ function markdown(list, path, options) {
 	// TODO: implement filtering, usage disabled for now
 	options.nofilter = true;
 
+	this.toolbarOptions = options.toolbarOptions || {};
 	this.height = options.height || 90;
 	markdown.super_.call(this, list, path, options);
 

--- a/public/js/common/ui-markdown.js
+++ b/public/js/common/ui-markdown.js
@@ -57,7 +57,10 @@ jQuery(function($) {
   };
 
   $('textarea.markdown').each(function () {
-    var hiddenButtons = ['Heading'];
+    var hiddenButtons = ['Heading'],
+        buttonsToHide = $(this).attr('data-toolbar-hidden-buttons');
+    if(buttonsToHide) { hiddenButtons = hiddenButtons.concat( buttonsToHide.split(',') ); }
+    
     $(this).markdown( $.extend({ hiddenButtons: hiddenButtons }, markdownOptions) );
   });
 

--- a/templates/fields/markdown/form.jade
+++ b/templates/fields/markdown/form.jade
@@ -4,6 +4,6 @@
 		if field.noedit
 			.field-value!= item.get(field.paths.html)
 		else
-			textarea(name=field.path, style='height: #{field.height}px').form-control.markdown= item.get(field.paths.md)
+			textarea(name=field.path, style='height: #{field.height}px', data-toolbar-hidden-buttons=field.toolbarOptions.hiddenButtons).form-control.markdown.code= item.get(field.paths.md)
 		if field.note
 			.field-note!= field.note

--- a/templates/fields/markdown/initial.jade
+++ b/templates/fields/markdown/initial.jade
@@ -1,6 +1,6 @@
 .field.type-markdown
     label.field-label= field.label
     .field-ui(class='width-' + field.width)
-        textarea(name=field.path, style='height: #{field.height}px').form-control.markdown= item[field.path]
+        textarea(name=field.path, style='height: #{field.height}px', data-toolbar-hidden-buttons=field.toolbarOptions.hiddenButtons).form-control.markdown.code= item[field.path]
         if field.note
             .field-note!= field.note


### PR DESCRIPTION
Hi there,
I've added some missing buttons in the Markdown toolbar (H1 to H6).
Moreover, I've added an option to the MD field: `toolbarOptions`.
That option is an object that could accept several keys in order to customise the toolbar. Currently, I've implemented only the `hiddenButtons` key (it is a comma separated list of buttons to hide).

```
toolbarOptions: { hiddenButtons: 'H1,Image,Quote' }
```

I've also updated the docs with an example.
