### PR TITLE
Use mv module to rename files across devices

### DIFF
--- a/lib/fieldTypes/localfile.js
+++ b/lib/fieldTypes/localfile.js
@@ -4,6 +4,7 @@
 
 var fs = require('fs'),
 	path = require('path'),
+	mv = require('mv'),
 	_ = require('underscore'),
 	moment = require('moment'),
 	async = require('async'),
@@ -291,7 +292,7 @@ localfile.prototype.uploadFile = function(item, file, update, callback) {
 			name = field.options.filename(item, name);
 		}
 
-		fs.rename(file.path, path.join(field.options.dest, name), function(err) {
+		mv(file.path, path.join(field.options.dest, name), function(err) {
 			
 			if (err) return callback(err);
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "moment": "~2.8.1",
     "mongoose": "~3.8.12",
     "mpromise": "~0.5.1",
+    "mv": "^2.0.3",
     "numeral": "~1.5.3",
     "queryfilter": "~0.0.4",
     "range_check": "~0.0.4",


### PR DESCRIPTION
I've been getting an [EXDEV](http://stackoverflow.com/questions/21071303/node-js-exdev-rename-error) error when trying to move the tmp file to the destination folder due to /tmp being on a different device to the destination. This PR simply adds the `mv` module and drops it in place of `fs.rename`.
