### PR TITLE
Preserve sort order of list elements

### DIFF
--- a/lib/schemaPlugins.js
+++ b/lib/schemaPlugins.js
@@ -2,7 +2,8 @@ var keystone = require('../'),
 	Types = require('./fieldTypes'),
 	_ = require('underscore'),
 	async = require('async'),
-	utils = require('keystone-utils');
+	utils = require('keystone-utils'),
+	mongoose = require('mongoose');
 
 var methods = module.exports.methods = {};
 var options = module.exports.options = {};
@@ -17,7 +18,9 @@ exports.sortable = function() {
 
 	this.schema.pre('save', function(next) {
 
-		if (typeof this.sortOrder === 'number') {
+		var sortOrderType = this.schema.path('sortOrder');
+		if ((typeof sortOrderType !== 'undefined')
+				&& (sortOrderType instanceof mongoose.Schema.Types.Number)) {
 			return next();
 		}
 


### PR DESCRIPTION
Saving items with partially fetched fields from DB will lead to overwrite of 'sortOrder' field with max value for this field in the list.

Changed behavior:
check for 'sortOrder' field presence in schema.
