### PR TITLE
Don't crash process on schema validation errors

### DIFF
--- a/lib/core/mount.js
+++ b/lib/core/mount.js
@@ -538,7 +538,7 @@ function mount(mountPath, parentApp, events) {
 		
 		if (mongoConnectionOpen) {
 			if (err.name === 'ValidationError') return;
-			throw new Error('Mongo Error');
+			throw err;
 		} else {
 			throw new Error('KeystoneJS (' + keystone.get('name') + ') failed to start');
 		}


### PR DESCRIPTION
The current behaviour is to take down the process any time there's an error on the mongoose connection. This includes schema validation errors.

I suggest we log those errors (if logger is true), but do not crash on them.
