### PR TITLE
Custom deletion hook error messages: issue #536

### DIFF
--- a/public/js/views/list.js
+++ b/public/js/views/list.js
@@ -302,8 +302,9 @@ jQuery(function($) {
 				err = err.responseJSON;
 			}
 			var errorMessage = 'There was an error deleting the ' + Keystone.list.singular.toLowerCase() + '.';
-			if (err && err.error) {
-				errorMessage += ' ( error: ' + err.error + ')';
+			var errorDetail = err ? err.detail || err.error : '';
+			if (errorDetail) {
+				errorMessage += ' ( error: ' + errorDetail + ')';
 			}
 			alert(errorMessage);
 			$row.removeClass('delete-inprogress');

--- a/routes/api/list.js
+++ b/routes/api/list.js
@@ -18,7 +18,7 @@ exports = module.exports = function(req, res) {
 			console.log(err);
 		}
 		res.status(500);
-		sendResponse({ error: key || 'error', detail: err });
+		sendResponse({ error: key || 'error', detail: err ? err.message : '' });
 	};
 
 	switch (req.params.action) {

--- a/routes/views/list.js
+++ b/routes/views/list.js
@@ -187,7 +187,7 @@ exports = module.exports = function(req, res) {
 				if (err) {
 					console.log('Error deleting ' + req.list.singular);
 					console.log(err);
-					req.flash('error', 'There was an error deleting ' + req.list.singular + ' (logged to console)');
+					req.flash('error', 'Error deleting the ' + req.list.singular + ': ' + err.message);
 				} else {
 					req.flash('success', req.list.singular + ' deleted successfully.');
 				}


### PR DESCRIPTION
I looked into issue #536. 

Errors were showing up correctly with 'save' hooks because non autocreated saves are handled by the updateHandler, which will display a flash message with the error message so long as the flasherrors option is set to true.

If there is a remove, item.remove() is called in the list route controller. The callback did not add the error's message into the flash message. 

I made a few tweaks so that the error message is added into the flash message. I also made changes to the list api so that an error message is sent in the response json. Then I made sure the message was properly displayed in the alert box when the trashcan icon was clicked.

Here's a quick example:

-- (in User.js) --
User.schema.pre('remove', function(next) {
    return next(new Error("Deleting users is not possible."));
});

-- (in browser) --
![working fix](https://cloud.githubusercontent.com/assets/7054089/4511759/ab3ee56c-4b38-11e4-88ea-6e9a66d157eb.png)
