### PR TITLE
Email: Mandrill templates and render support.

### DIFF
--- a/lib/email.js
+++ b/lib/email.js
@@ -422,7 +422,7 @@ Email.prototype.buildOptions = function(err, options, callback) {
 
 		if ('string' === typeof options.to[i]) {
 			options.to[i] = { email: options.to[i] };
-		} else if ('object' === typeof options.to[i]) {
+		} else if ('object' === typeof options.to[i] && options.to[i] !== null) {
 
 			if (!options.to[i].email) {
 				return callback({


### PR DESCRIPTION
Added support to send emails via Mandrill templates. New constructor options:
- `options.templateMandrillName`: Mandrill template name.
- `options.templateForceHtml`: Allows hybrid method that uses a Mandrill template but sends html too.

With a new method to render them locally: `renderMandrill`.

Added support for `globalMergeVariables` (object that is converted to Mandrill's format, see below) and `global_merge_variables`.

Added support for custom `merge_variables` as a recipient's attribute `vars`, that is flattened and converted from an object to the Mandrill's format (via `objToMandrillVars` function):

```
{ foo: 'bar', da: 'fus', hey: { ho: 'lets go' } }
=>
[{ name: 'foo', content: 'bar' }, { name: 'da', content: 'fus' }, { name: 'hey_ho', content: 'lets go' }]
```

_Notes:_
- There's no specific test for emails so I've tested it with my project's tests and it works.
- There's no documentation about the email lib but I don't have enough time to write a new section right now :(
