### PR TITLE
Fix for user undefined after ajax remove item from list

### DIFF
--- a/templates/mixins/rows.jade
+++ b/templates/mixins/rows.jade
@@ -2,7 +2,7 @@ include columns
 
 mixin row(list, colums, item)
   tr(id=item.id)
-    if !list.get('nodelete') && item.id !== user.id
+    if !list.get('nodelete') && ( user && item.id !== user.id )
       td.control: a(href='/keystone/' + list.path + '?delete=' + item.id + csrf_query).control-delete
     else if !list.get('nodelete')
       td.control


### PR DESCRIPTION
After an ajax remove item call from the items list, with some lists, Admin UI crashes on `fetch` because user is undefined.

Delete operation returns a correct status and the item is removed correctly. I cannot reproduce the issue with every list but I've been able to reproduce it with one of our lists.

This change fixes this issue until a better solution.

The crash:

```

TypeError: 
/node_modules/keystone/templates/mixins/rows.jade:5
    3| mixin row(list, colums, item)
    4|   tr(id=item.id)
  > 5|     if !list.get('nodelete') && item.id !== user.id
    6|       td.control: a(href='/keystone/' + list.path + '?delete=' + item.id + csrf_query).control-delete
    7|     else if !list.get('nodelete')
    8|       td.control

Cannot read property 'id' of undefined
  at Object.jade_mixins.row (<anonymous>:274:47)
  at eval (<anonymous>:374:19)
  at eval (<anonymous>:376:22)
...
```
