### PR TITLE
Fix missing space when ordered.

### DIFF
--- a/templates/views/list.jade
+++ b/templates/views/list.jade
@@ -101,7 +101,7 @@ block content
 				//- Sort
 				if items.results.length
 					if sort.by
-						span.text-muted ordered by&nbsp;
+						span.text-muted &nbsp;ordered by&nbsp;
 					else
 						span.text-muted &mdash;
 					span.dropdown.list-sort-dropdown


### PR DESCRIPTION
There was a space missing on the text when ordered by a field.
