### PR TITLE
added support for markdown field

### DIFF
--- a/admin/src/fields.js
+++ b/admin/src/fields.js
@@ -4,6 +4,7 @@ module.exports = {
 	datetime:	require('../../fields/types/datetime/datetime'),
 	email:		require('../../fields/types/email/email'),
 	location:	require('../../fields/types/location/location'),
+	markdown:	require('../../fields/types/markdown/markdown'),
 	name:		require('../../fields/types/name/name'),
 	select:		require('../../fields/types/select/select'),
 	text:		require('../../fields/types/text/text')

--- a/fields/types/markdown/markdown.js
+++ b/fields/types/markdown/markdown.js
@@ -1,0 +1,114 @@
+var React = require('react'),
+	Field = require('../field'),
+	// need jquery so we can get the markdown plugin to mount
+	jQuery = require('jquery'),
+	// scope our bootstrap-markdown plugin onto jquery
+	Markdown = require('../../../public/js/lib/bootstrap-markdown/js/bootstrap-markdown.js');
+	
+module.exports = Field.create({
+	
+	supports: {
+		width: true
+	},
+	
+	componentDidMount: function() {
+		var markdownOptions = {
+			autofocus: false,
+			savable: false,
+			additionalButtons: this.buttonsToAdd(),
+			reorderButtonGroups: ['groupFont', 'groupHeaders', 'groupLink', 'groupMisc', 'groupUtil']
+		};
+
+		// only have access to `refs` during componentDidMount
+		$(this.refs.markdownTextarea.getDOMNode()).markdown(markdownOptions);
+	},
+	
+	// Add all H1 to H6 buttons
+	buttonsToAdd: function() {
+		// Append/remove ### surround the selection 
+		// Source: https://github.com/toopay/bootstrap-markdown/blob/master/js/bootstrap-markdown.js#L909
+		var headingCallback = function (e, hType) {
+			var chunk, cursor, selected = e.getSelection(), content = e.getContent(), pointer, prevChar;
+
+			if (selected.length == 0) {
+				// Give extra word
+				chunk = e.__localize('heading text');
+			} else {
+				chunk = selected.text + '\n';
+			}
+
+			// transform selection and set the cursor into chunked text
+			if ((pointer = hType.length+1, content.substr(selected.start-pointer,pointer) == hType+' ')
+				|| (pointer = hType.length, content.substr(selected.start-pointer,pointer) == hType)) {
+				e.setSelection(selected.start-pointer,selected.end);
+				e.replaceSelection(chunk);
+				cursor = selected.start-pointer;
+			} else if (selected.start > 0 && (prevChar = content.substr(selected.start-1,1), !!prevChar && prevChar != '\n')) {
+				e.replaceSelection('\n\n'+hType+' '+chunk);
+				cursor = selected.start+hType.length+3;
+			} else {
+				// Empty string before element
+				e.replaceSelection(hType+' '+chunk);
+				cursor = selected.start+hType.length+1;
+			}
+
+			// Set the cursor
+			e.setSelection(cursor,cursor+chunk.length);
+		};
+		
+		return [{
+			name: 'groupHeaders',
+			data: [{
+				name: 'cmdH1',
+				title: 'Heading 1',
+				btnText: 'H1',
+				callback: function(e){
+					headingCallback(e, '#');
+				}
+			},{
+				name: 'cmdH2',
+				title: 'Heading 2',
+				btnText: 'H2',
+				callback: function(e){
+					headingCallback(e, '##');
+				}
+			},{
+				name: 'cmdH3',
+				title: 'Heading 3',
+				btnText: 'H3',
+				callback: function(e){
+					headingCallback(e, '###');
+				}
+			},{
+				name: 'cmdH4',
+				title: 'Heading 4',
+				btnText: 'H4',
+				callback: function(e){
+					headingCallback(e, '####');
+				}
+			},{
+				name: 'cmdH5',
+				title: 'Heading 5',
+				btnText: 'H5',
+				callback: function(e){
+					headingCallback(e, '##');
+				}
+			},{
+				name: 'cmdH6',
+				title: 'Heading 6',
+				btnText: 'H6',
+				callback: function(e){
+					headingCallback(e, '##');
+				}
+			}]
+		}];
+	},
+	
+	renderField: function() {
+		return (
+			<div className="md-editor">
+				<textarea defaultValue={this.props.value.md} ref="markdownTextarea" className="form-control markdown code md-input"></textarea>
+			</div>
+		);
+	}
+});

--- a/public/js/lib/bootstrap-markdown/js/bootstrap-markdown.js
+++ b/public/js/lib/bootstrap-markdown/js/bootstrap-markdown.js
@@ -17,6 +17,9 @@
  * limitations under the License.
  * ========================================================== */
 
+// import marked into module so browserify can scope
+var marked = require('marked');
+
 !function ($) {
 
   "use strict"; // jshint ;_;


### PR DESCRIPTION
## Work

![react-markdown-demo](https://cloud.githubusercontent.com/assets/89339/5082839/d413e684-6eb7-11e4-9563-c274ac3d59ab.gif)
## Implementation Notes

First attempt at react component field.  I wanted to reuse as much of the code that was already in place (aka reuse bootstrap-markdown).  In order to do this I bundled jquery into browserify so that the bootstrap-markdown would mount onto `$.()`.  From there I used the react `ref` method to hand off the currentDom node.  I ran into an issue with `marked` not being scoped from within the boostrap-markdown, this meant the preview button would not render html processed by marked.  To fix the issue I `required` marked in the boostrap-markdown.js so that it would be scoped accordingly.

p.s. sorry if the spacing is all messed up, sublime doesn't like my tabs and I kept pasting code from a vim window which has soft-spaces.
