### PR TITLE
Allow addition of external links to admin menu

### DIFF
--- a/lib/core/initNav.js
+++ b/lib/core/initNav.js
@@ -39,17 +39,27 @@ function initNav(sections) {
 		};
 		section.key = key;
 		section.lists = _.map(section.lists, function(i) {
-			var msg, list = keystone.list(i);
-			if (!list) {
-				msg = 'Invalid Keystone Option (nav): list ' + i + ' has not been defined.\n';
-				throw new Error(msg);
+			var msg;
+			if ( _.isString(i)){
+				var list = keystone.list(i);
+				if (!list) {
+					msg = 'Invalid Keystone Option (nav): list ' + i + ' has not been defined.\n';
+					throw new Error(msg);
+				}
+				if (list.get('hidden')) {
+					msg = 'Invalid Keystone Option (nav): list ' + i + ' is hidden.\n';
+					throw new Error(msg);
+				}
+				list.path = "/keystone/" + list.path;
+				nav.by.list[list.key] = section;
+				return list;
+			}else if ( _.isObject(i)){
+				nav.by.list[i.key] = section;
+				return i;
 			}
-			if (list.get('hidden')) {
-				msg = 'Invalid Keystone Option (nav): list ' + i + ' is hidden.\n';
-				throw new Error(msg);
-			}
-			nav.by.list[list.key] = section;
-			return list;
+			
+			msg = 'Invalid Keystone Option (nav): list ' + i + ' is in an unrecognized format.\n';
+			throw new Error(msg);
 		});
 		if (section.lists.length) {
 			nav.sections.push(section);

--- a/templates/layout/base.jade
+++ b/templates/layout/base.jade
@@ -41,7 +41,7 @@ html
 							li: a(href=signout).signout Sign Out
 					ul.nav.navbar-nav
 						each navSection in nav.sections
-							li(class=section.key == navSection.key ? 'active' : null): a(href='/keystone/' + navSection.lists[0].path)= navSection.label
+							li(class=section.key == navSection.key ? 'active' : null): a(href=navSection.lists[0].path)= navSection.label
 			if section.lists && section.lists.length > 1
 				nav(role='navigation')#section-nav.navbar.navbar-default.navbar-static-top: .container
 					.navbar-header
@@ -57,7 +57,7 @@ html
 					.collapse.navbar-collapse.navbar-sectionnav-collapse
 						ul.nav.navbar-nav
 							each navList in section.lists
-								li(class=navList.key == list.key ? 'active' : null): a(href='/keystone/' + navList.path)= navList.label
+								li(class=navList.key == list.key ? 'active' : null): a(href=navList.path)= navList.label
 			#body: .container
 				block intro
 				+flash-messages(messages)


### PR DESCRIPTION
Since the admin section is currently not easily customizable, and I **really** needed to be able to link from the admin menu to something else than a list page I added the possibility to add links to the admin menu from your application specific `keystone.js` file.

E.g.:

``` js
//keystone.js

keystone.set( 'nav', {
  'content'     : [
    'posts',
    'post-categories',
    'enquiries'
  ],
  'reports' : [
    {
      label: "Comparisons Report",
      key : "comparisons-report",
      path : "/reporting/comparisons"
    }
  ]
);
```

This will render a "Comparisons Report" in the admin menu under a "reports" section and when clicked upon will point the browser to `<host>/reporting/comparisons`.
Thus, all you need to do in your (application) `/routes/index.js` is add a route binding.

A link entry should always have all 3 props `label`, `key` and `path`. And obviously `path` could contain an external url as well.
These link entries can be mixed with lists, e.g.:

``` js
//keystone.js

keystone.set( 'nav', {
  'content'     : [
    'posts',
    'post-categories',
    'enquiries',
    {
      label: "Comparisons Report",
      key : "comparisons-report",
      path : "/reporting/comparisons"
    }
  ]
);
```

If the docs need updating, or anything is wrong or unclear: let me know!
