### PR TITLE
Email - updated argument handler to work without callback

### DIFF
--- a/lib/email.js
+++ b/lib/email.js
@@ -546,13 +546,26 @@ Email.prototype.send = function(options, callback) {
 
 	var prepareOptions = [locals];
 
-	if (arguments.length === 3 || !utils.isFunction(callback)) {
+	if (arguments.length === 3 ) {
+		// we expect locals,options,callback
 		callback = arguments[2];
-		options = arguments[1] || arguments[0];
+		options = arguments[1];
 		prepareOptions.push(options);
-	}
-
-	callback = ('function' === typeof callback) ? callback : function() {};
+	} else if (arguments.length === 2 && !utils.isFunction(callback)) {
+		//no callback so we expect locals,options
+		callback = function(err,info){if(err)console.log(err)};
+		options = arguments[1];
+		prepareOptions.push(options);
+	} else if (arguments.length === 2 && utils.isFunction(callback)) {
+		// callback so we expect options,callback
+		// this is redundant but is easy to read
+		callback = callback;
+		// options pushed already
+		
+	} else if(arguments.length === 1) {
+		// we expect options here and it is pushed already
+		var callback = function(err,info){if(err)console.log(err)};
+	}  
 
 	prepareOptions.push(function(err, toSend) {
 


### PR DESCRIPTION
The method seems convoluted, but correctly applies the callback.  Please feel free to update it if it is too long.
