### PR TITLE
Adds appversion rendering to footer

### DIFF
--- a/lib/core/render.js
+++ b/lib/core/render.js
@@ -50,6 +50,7 @@ function render(req, res, view, ext) {
 		numeral: numeral,
 		env: keystone.get('env'),
 		brand: keystone.get('brand'),
+		appversion : keystone.get('appversion'),
 		nav: keystone.nav,
 		messages: _.any(flashMessages, function(msgs) { return msgs.length; }) ? flashMessages : false,
 		lists: keystone.lists,

--- a/templates/layout/base.jade
+++ b/templates/layout/base.jade
@@ -74,7 +74,8 @@ html
 				block content
 
 		#footer: .container
-			p Powered by <a href="http://keystonejs.com" target="_blank">KeystoneJS</a> version #{version}.
+			p 	#{brand} #{appversion} 
+				| Powered by <a href="http://keystonejs.com" target="_blank">KeystoneJS</a> version #{version}.
 				if User && user
 					|  Signed in as 
 					a(href='/keystone/' + User.path + '/' + user.id)= User.getDocumentName(user)


### PR DESCRIPTION
I almost always add a version number display to my apps for various reasons: people can refer to it when encountering bugs, it's an easy confirmation the application was rebooted after a release, etc.

This PR introduces a new setting `appversion` which is rendered (together with `brand`) in the footer.

Usage examples:

``` js
//file: keystone.js
keystone.init( {
  'name'  : 'd-pac',
  'brand' : 'd-pac',
  'appversion' : require("./package.json").version
} );
```

or

``` js
keystone.set('appversion', "0.5.4");
```

Which will get rendered as (on a retina resolution):

![footer](https://www.evernote.com/shard/s59/sh/8c857513-1f2b-44ae-a371-29451331471c/4e8de93435c941ba9eacf35cc323dfe7/res/bc5a9ed3-5bac-4f2e-a2ed-1e25e659b576/skitch.png)

Sidenote: TBH I think it would be better to store an `app` object, sth like:

``` js
'app' : {
  'name'  : 'd-pac',
  'brand' : 'd-pac',
  'version' : require("./package.json").version   
}
```

But I'm a bit hesitant to make the necessary changes, since it's a bit hard to track down all places where `name` is used for instance ( a search will yield 1000+ results). 
