### PR TITLE
Add check for refsLookup existence to core/createItem

### DIFF
--- a/lib/core/createItems.js
+++ b/lib/core/createItems.js
@@ -214,7 +214,7 @@ function createItems(data, ops, callback) {
 							if (field.many) {
 								
 								var refsArr = _.compact(fieldValue.map(function(ref) {
-									return refsLookup[ref] ? refsLookup[ref].id : undefined;
+									return refsLookup && refsLookup[ref] ? refsLookup[ref].id : undefined;
 								}));
 								
 								if (options.strict && refsArr.length !== fieldValue.length) {
@@ -239,7 +239,7 @@ function createItems(data, ops, callback) {
 							
 						} else if (_.isString(fieldValue)) {
 							
-							var refItem = refsLookup[fieldValue];
+							var refItem = refsLookup && refsLookup[fieldValue];
 							
 							if (!refItem) {
 								return options.strict ? doneField({


### PR DESCRIPTION
Currently createItem will fail if you have a relationship to a list that it has no relationships for.
