### PR TITLE
Initial template for TextArray, NumberArray fields

### DIFF
--- a/templates/fields/textarray/initial.jade
+++ b/templates/fields/textarray/initial.jade
@@ -1,6 +1,10 @@
-.field(class='type-' + field.type)
+.field(class='type-' + field.type, data-field-type=field.type, data-field-path=field.path, data-field-collapse=field.collapse ? 'true' : false, data-field-depends-on=field.dependsOn, data-field-noedit=field.noedit ? 'true' : 'false')
 	label.field-label= field.label
 	.field-ui(class='width-' + field.width)
-		input(type='text', name=field.path, value=item[field.path] || field.options.default, autocomplete='off').form-control
+		div.field-item
+			input(type='text', name=field.path, value=value, autocomplete='off').form-control.multi
+			a.btn.btn-link.btn-cancel.btn-remove-item(href=js): span.ion-close-round
+		a.btn.btn-xs.btn-default.btn-add-item(href=js)
+			| Add item
 		if field.note
 			.field-note!= field.note


### PR DESCRIPTION
Proper initial.jade for TextArray fields, used by NumberArray fields as well.

This can actually matter if your models contain fields requiring (sic) more than one value, and you don't feel like setting default values for them (my case: geographical coordinates).
