### PR TITLE
Handle undefined boolean update values

### DIFF
--- a/lib/fieldTypes/boolean.js
+++ b/lib/fieldTypes/boolean.js
@@ -57,7 +57,7 @@ boolean.prototype.updateItem = function(item, data) {
 		if (!item.get(this.path)) {
 			item.set(this.path, true);
 		}
-	} else if (item.get(this.path) !== false) {
+	} else if (value === false || value === 'false' && item.get(this.path) !== false) {
 		item.set(this.path, false);
 	}
 


### PR DESCRIPTION
Handle undefined boolean update values.  Explicitly check that the new update value is actually false before setting the item path to false, which potentially and unintentionally may override the established item path default value.
