### PR TITLE
Make `addItem` button work for array fields.

### DIFF
--- a/fields/mixins/arrayfield.js
+++ b/fields/mixins/arrayfield.js
@@ -24,8 +24,7 @@ module.exports = {
 	},
 	
 	addItem: function() {
-		var newItem = newItem('');
-		var newValues = this.state.values.concat();
+		var newValues = this.state.values.concat(newItem(''));
 		this.setState({
 			values: newValues
 		});


### PR DESCRIPTION
It logged an error to console before.
