### PR TITLE
Server hangs during initialization when using redis as SessionStore

### DIFF
--- a/lib/core/mount.js
+++ b/lib/core/mount.js
@@ -127,22 +127,12 @@ function mount(mountPath, parentApp, events) {
 		switch (sessionStore) {
 			
 			case 'mongo':
-				// default session store for using MongoDB
-				sessionStore = 'connect-mongo';
-				// same as connect-mongo defaults
-				_.defaults(sessionStoreOptions, {
-					collection: 'app_sessions',
-					url: this.get('mongo')
-				});
-				break;
-				
 			case 'connect-mongo':
 				_.defaults(sessionStoreOptions, {
 					collection: 'app_sessions',
 					url: this.get('mongo')
 				});
 				break;
-
 			case 'connect-mongostore':
 				_.defaults(sessionStoreOptions, {
 					collection: 'app_sessions'


### PR DESCRIPTION
Hi,

connect-redis does not have a 'ready' callback like connect-mongo does, so when trying to use redis, the server hangs.

You can verify that [here](https://github.com/kcbanner/connect-mongo/blob/master/lib/connect-mongo.js#L63) and [here](https://github.com/tj/connect-redis/blob/master/lib/connect-redis.js#L42)

As the the promise is never fulfilled, the server waits forever.

Also this is my first pull request here, I just started messing around with Keystone :) So I'm not sure if I made any mistakes.
