### PR TITLE
Fixing the XHR bug where the json is assumed to be a string in IE

### DIFF
--- a/admin/client/utils/List.js
+++ b/admin/client/utils/List.js
@@ -95,6 +95,7 @@ List.prototype.createItem = function (formData, callback) {
 	xhr({
 		url: `${Keystone.adminPath}/api/${this.path}/create`,
 		responseType: 'json',
+		json: true,
 		method: 'POST',
 		headers: assign({}, Keystone.csrf.header),
 		body: formData,
@@ -123,6 +124,7 @@ List.prototype.updateItem = function (id, formData, callback) {
 	xhr({
 		url: `${Keystone.adminPath}/api/${this.path}/${id}`,
 		responseType: 'json',
+		json: true,
 		method: 'POST',
 		headers: assign({}, Keystone.csrf.header),
 		body: formData,
@@ -232,6 +234,7 @@ List.prototype.loadItem = function (itemId, options, callback) {
 	xhr({
 		url: url,
 		responseType: 'json',
+		json: true,
 	}, (err, resp, data) => {
 		if (err) return callback(err);
 		// Pass the data as result or error, depending on the statusCode
@@ -255,6 +258,7 @@ List.prototype.loadItems = function (options, callback) {
 	xhr({
 		url: url,
 		responseType: 'json',
+		json: true,
 	}, (err, resp, data) => {
 		if (err) callback(err);
 		// Pass the data as result or error, depending on the statusCode


### PR DESCRIPTION
<!--

 Please make sure the following is filled in before submitting your Pull Request - thanks!

 -->

## Description of changes
Updates all XHR request that are trying to request json data to include the option of `json: true`. Without this option IE treats the responses as a string. 


## Related issues (if any)
Fixes #3734

## Testing

- [ ] Please confirm `npm run test-all` ran successfully.

<!--

 Notes:

 * To successfully have all e2e tests pass you need to have the following setup:
    - a recent version of the chrome browser
    - java 1.8+
 * If you are developing in Windows you may run into linebreak linting issues.
   One possible workaround is to remove the "linebreak-style" rule in `node_modules/eslint-config-keystone/eslintrc.json`.

 -->

