### PR TITLE
Fix default value not used in fields-explorer

### DIFF
--- a/fields/explorer/components/FieldType.js
+++ b/fields/explorer/components/FieldType.js
@@ -76,6 +76,7 @@ const ExplorerFieldType = React.createClass({
 										FieldComponent={FieldComponent}
 										FilterComponent={FilterComponent}
 										spec={spec}
+										value={this.state.value}
 										readmeIsVisible={readmeIsVisible}
 									/>
 								))}


### PR DESCRIPTION
When set value in spec object it not used
module.exports = {
	Field: require('../FileField'),
	Filter: require('../FileFilter'),
	readme: require('fs').readFileSync('./fields/types/file/Readme.md', 'utf8'),
	section: 'Miscellaneous',
	spec: {
		label: 'File',
		path: 'file',
		value: {
			"url": "https://dgbyuz0hxemz2.cloudfront.net/avatars/ZYxiqBgSYpa2qbW_",
			"size": 640971,
			"filename": "ZYxiqBgSYpa2qbW_",
			"mimetype": "image/png"
		},
	},
};

<!--
 Please make sure the following is filled in before submitting your Pull Request - thanks!

 Join the KeystoneJS Slack for discussion with the community & contributors:
  * https://launchpass.com/keystonejs
 -->

## Description of changes


## Related issues (if any)


## Testing

 - [x] List browser version(s) any admin UI changes were tested in:
 - [x] Please confirm you've added (or verified) test coverage for this change.
 - [x] Please confirm `npm run test-all` ran successfully.

<!--
 Notes:
 * For more information on the End-2-End (E2E) testing framework for Keystone 4, see:
    https://github.com/keystonejs/keystone-nightwatch-e2e
 * To successfully have all E2E tests pass you need to have the following set up:
    - A recent version of Chrome or Firefox
    - Java Runtime Environment 1.8+
 * If you are developing in Windows you may run into linebreak linting issues.
   One possible workaround is to remove the "linebreak-style" rule in `node_modules/eslint-config-keystone/eslintrc.json`.
 -->

