### PR TITLE
Update cloudinary.ks

### DIFF
--- a/admin/server/api/cloudinary.js
+++ b/admin/server/api/cloudinary.js
@@ -10,6 +10,10 @@ module.exports = {
 		if (req.files && req.files.file) {
 			var options = {};
 
+			if (keystone.get('wysiwyg cloudinary images folder')) {
+      	options.folder = keystone.get('wysiwyg cloudinary images folder');
+      }
+			
 			if (keystone.get('wysiwyg cloudinary images filenameAsPublicID')) {
 				options.public_id = req.files.file.originalname.substring(0, req.files.file.originalname.lastIndexOf('.'));
 			}


### PR DESCRIPTION
Why not adding something like this?

  if (keystone.get('wysiwyg cloudinary images folder')) {
      options.folder = keystone.get('wysiwyg cloudinary images folder');
  }

It's a new configuration and permits to specify folder for both TinyMCE image upload.

At the moment everything goes directly in cloudinary root folder.

Thanks!

<!--
 Please make sure the following is filled in before submitting your Pull Request - thanks!

 Join the KeystoneJS Slack for discussion with the community & contributors:
  * https://launchpass.com/keystonejs
 -->

## Description of changes


## Related issues (if any)


## Testing

 - [ ] List browser version(s) any admin UI changes were tested in:
 - [ ] Please confirm you've added (or verified) test coverage for this change.
 - [ ] Please confirm `npm run test-all` ran successfully.

<!--
 Notes:
 * For more information on the End-2-End (E2E) testing framework for Keystone 4, see:
    https://github.com/keystonejs/keystone-nightwatch-e2e
 * To successfully have all E2E tests pass you need to have the following set up:
    - A recent version of Chrome or Firefox
    - Java Runtime Environment 1.8+
 * If you are developing in Windows you may run into linebreak linting issues.
   One possible workaround is to remove the "linebreak-style" rule in `node_modules/eslint-config-keystone/eslintrc.json`.
 -->

