### PR TITLE
Fix problem with filename ext (ticket: #4765)

### DIFF
--- a/lib/storage/adapters/fs/index.js
+++ b/lib/storage/adapters/fs/index.js
@@ -94,7 +94,7 @@ FSAdapter.prototype.uploadFile = function (file, callback) {
 	var options = this.options;
 	this.getFilename(file, function (err, filename) {
 		if (err) return callback(err);
-		filename = sanitize(filename);
+		filename = sanitize(filename) + path.parse(file.originalname).ext;
 		debug('Uploading file with filename: %s', filename);
 		var uploadPath = path.resolve(options.path, filename);
 		var fsOptions = {};


### PR DESCRIPTION
Hi guys. This is just fix for this ticket: https://github.com/keystonejs/keystone/issues/4765

I am using keystone on 3 different servers and always I have this problem with saving files. This solution working everythere. 