### PR TITLE
Using multer options for CRUD operations on admin UI fields

### DIFF
--- a/admin/server/app/createDynamicRouter.js
+++ b/admin/server/app/createDynamicRouter.js
@@ -3,7 +3,7 @@ var express = require('express');
 
 var uploads = require('../../../lib/uploads');
 
-module.exports = function createDynamicRouter(keystone) {
+module.exports = function createDynamicRouter (keystone) {
 	// ensure keystone nav has been initialised
 	// TODO: move this elsewhere (on demand generation, or client-side?)
 	if (!keystone.nav) {

--- a/admin/server/app/createDynamicRouter.js
+++ b/admin/server/app/createDynamicRouter.js
@@ -3,7 +3,7 @@ var express = require('express');
 
 var uploads = require('../../../lib/uploads');
 
-module.exports = function createDynamicRouter (keystone) {
+module.exports = function createDynamicRouter(keystone) {
 	// ensure keystone nav has been initialised
 	// TODO: move this elsewhere (on demand generation, or client-side?)
 	if (!keystone.nav) {
@@ -18,7 +18,7 @@ module.exports = function createDynamicRouter (keystone) {
 	// Use bodyParser and multer to parse request bodies and file uploads
 	router.use(bodyParser.json({}));
 	router.use(bodyParser.urlencoded({ extended: true }));
-	uploads.configure(router);
+	uploads.configure(router, keystone.get('multer options'));
 
 	// Bind the request to the keystone instance
 	router.use(function (req, res, next) {


### PR DESCRIPTION
Currently it is not possible to save texts fields in the admin UI that exceed the default multer limit of 1mb.

## Description of changes

To set custom multer options it is currently necessary to set 'handle uploads' to true and define an object with the key 'multer options'.

`'multer options': {
            dest: tmpdir(),
            limits: {
                fieldSize: 25 * 1024 * 1024 //25 mb
            }
        },
        'handle uploads': true,`

These options are currently being applied during the setup of body-parser (server/bindBodyParser.js).

This pull request would also apply the options in the dynamic router (admin/server/app/createDynamicRouter.js) where multer is being used to process updates to fields in the admin UI.

## Related issues (if any)
#4843

## Testing

(!) WIP currently eslint fails with 291 problems (291 errors, 0 warnings) on my MacOS setup.

 - [ ] List browser version(s) any admin UI changes were tested in:
 - [ ] Please confirm you've added (or verified) test coverage for this change.
 - [ ] Please confirm `npm run test-all` ran successfully.

<!--
 Notes:
 * For more information on the End-2-End (E2E) testing framework for Keystone 4, see:
    https://github.com/keystonejs/keystone-nightwatch-e2e
 * To successfully have all E2E tests pass you need to have the following set up:
    - A recent version of Chrome or Firefox
    - Java Runtime Environment 1.8+
 * If you are developing in Windows you may run into linebreak linting issues.
   One possible workaround is to remove the "linebreak-style" rule in `node_modules/eslint-config-keystone/eslintrc.json`.
 -->

