### PR TITLE
Fixes #4919: Saving a model before Relationship fields have fully loaded causes data loss

### DIFF
--- a/admin/client/App/screens/Item/components/EditForm.js
+++ b/admin/client/App/screens/Item/components/EditForm.js
@@ -60,9 +60,14 @@ var EditForm = React.createClass({
 		list: React.PropTypes.object,
 	},
 	getInitialState () {
-		var hasAsyncFields = this.props.list.columns
-			.filter(col => col.field && col.field.type === 'relationship')
-			.length > 0;
+		var hasAsyncFields = !!this.props.list.columns.find(col => {
+			if (col.field && col.field.type === 'relationship') {
+				var fieldData = this.props.data.fields[col.field.path];
+				return col.field.many ? fieldData.length > 0 : fieldData;
+			} else {
+				return false;
+			}
+		});
 		return {
 			values: assign({}, this.props.data.fields),
 			confirmationDialog: null,
@@ -105,12 +110,12 @@ var EditForm = React.createClass({
 		return props;
 	},
 
-	registerAsyncField(fieldName) {
+	registerAsyncField (fieldName) {
 		this.__asyncFields = this.__asyncFields || {};
 		this.__asyncFields[fieldName] = this.__asyncFields[fieldName] || ASYNC_FIELD_LOADING;
 	},
 
-	onAsyncFieldValuesLoaded(fieldName) {
+	onAsyncFieldValuesLoaded (fieldName) {
 		this.__asyncFields[fieldName] = ASYNC_FIELD_LOADED;
 		var isLoadingComplete = Object.values(this.__asyncFields).filter(asyncStatus => asyncStatus !== ASYNC_FIELD_LOADED).length === 0;
 		this.setState({

--- a/admin/client/App/screens/Item/components/EditForm.js
+++ b/admin/client/App/screens/Item/components/EditForm.js
@@ -26,6 +26,8 @@ import { deleteItem } from '../actions';
 
 import { upcase } from '../../../../utils/string';
 
+import { ASYNC_FIELD_LOADING, ASYNC_FIELD_LOADED } from '../constants';
+
 function getNameFromData (data) {
 	if (typeof data === 'object') {
 		if (typeof data.first === 'string' && typeof data.last === 'string') {
@@ -58,10 +60,14 @@ var EditForm = React.createClass({
 		list: React.PropTypes.object,
 	},
 	getInitialState () {
+		var hasAsyncFields = this.props.list.columns
+			.filter(col => col.field && col.field.type === 'relationship')
+			.length > 0;
 		return {
 			values: assign({}, this.props.data.fields),
 			confirmationDialog: null,
-			loading: false,
+			loading: hasAsyncFields,
+			hasLoaded: !hasAsyncFields,
 			lastValues: null, // used for resetting
 			focusFirstField: !this.props.list.nameField && !this.props.list.nameFieldIsFormHeader,
 		};
@@ -88,8 +94,31 @@ var EditForm = React.createClass({
 		props.values = this.state.values;
 		props.onChange = this.handleChange;
 		props.mode = 'edit';
+
+		// add a callback on RelationshipField element props to call when values are fully loaded
+		if (props.type === 'relationship' && !this.state.hasLoaded) {
+			if (props.many && props.value.length > 0 || !props.many && !!props.value) {
+				this.registerAsyncField(field.path);
+				props.onValuesLoaded = this.onAsyncFieldValuesLoaded;
+			}
+		}
 		return props;
 	},
+
+	registerAsyncField(fieldName) {
+		this.__asyncFields = this.__asyncFields || {};
+		this.__asyncFields[fieldName] = this.__asyncFields[fieldName] || ASYNC_FIELD_LOADING;
+	},
+
+	onAsyncFieldValuesLoaded(fieldName) {
+		this.__asyncFields[fieldName] = ASYNC_FIELD_LOADED;
+		var isLoadingComplete = Object.values(this.__asyncFields).filter(asyncStatus => asyncStatus !== ASYNC_FIELD_LOADED).length === 0;
+		this.setState({
+			loading: !isLoadingComplete,
+			hasLoaded: isLoadingComplete
+		});
+	},
+
 	handleChange (event) {
 		const values = assign({}, this.state.values);
 
@@ -276,8 +305,12 @@ var EditForm = React.createClass({
 			return null;
 		}
 
-		const { loading } = this.state;
-		const loadingButtonText = loading ? 'Saving' : 'Save';
+		const { loading, hasLoaded } = this.state;
+		const loadingButtonText = loading
+			? hasLoaded
+				? 'Saving'
+				: 'Loading'
+			: 'Save';
 
 		// Padding must be applied inline so the FooterBar can determine its
 		// innerHeight at runtime. Aphrodite's styling comes later...

--- a/admin/client/App/screens/Item/constants.js
+++ b/admin/client/App/screens/Item/constants.js
@@ -5,3 +5,5 @@ export const DATA_LOADING_ERROR = 'app/Item/DATA_LOADING_ERROR';
 export const DRAG_MOVE_ITEM = 'app/Item/DRAG_MOVE_ITEM';
 export const DRAG_RESET_ITEMS = 'app/Item/DRAG_RESET_ITEMS';
 export const LOAD_RELATIONSHIP_DATA = 'app/Item/LOAD_RELATIONSHIP_DATA';
+export const ASYNC_FIELD_LOADING = 'loading';
+export const ASYNC_FIELD_LOADED = 'loaded';

--- a/fields/types/relationship/RelationshipField.js
+++ b/fields/types/relationship/RelationshipField.js
@@ -118,6 +118,9 @@ module.exports = Field.create({
 			});
 		}, (err, expanded) => {
 			if (!this.__isMounted) return;
+			if (this.props.onValuesLoaded && typeof this.props.onValuesLoaded === 'function') {
+				this.props.onValuesLoaded(this.props.path);
+			}
 			this.setState({
 				loading: false,
 				value: this.props.many ? expanded : expanded[0],


### PR DESCRIPTION
## Description of changes

Enhances the 'Save' button on the admin UI to act as a loading indicator while Relationship fields are populated and prevents the user from saving the model until all Relationship fields have completed loading.

## Related issues (if any)

#4919

## Testing

 - [x] List browser version(s) any admin UI changes were tested in:
    - Chrome Version 79.0.3945.117
 - [x] Please confirm you've added (or verified) test coverage for this change.
 - [x] Please confirm `npm run test-all` ran successfully.
_Tests passed at the same rate as they did prior to changes.  There are many linting issues (in unchanged files) and some tests that remain in the 'Pending' state indefinitely._
