### PR TITLE
fix function name for mime

### DIFF
--- a/lib/storage/index.js
+++ b/lib/storage/index.js
@@ -117,7 +117,7 @@ function getSize (file, callback) {
 function normalizeFile (file, schema, callback) {
 	// Detect required information if it wasn't provided by inspecting the
 	// file stored at file.path
-	if (schema.mimetype && !file.mimetype) file.mimetype = mime(file.path);
+	if (schema.mimetype && !file.mimetype) file.mimetype = mime.lookup(file.path);
 
 	if (!file.originalname) {
 		file.originalname = file.name


### PR DESCRIPTION
mime is not a function

<!--
 Please make sure the following is filled in before submitting your Pull Request - thanks!

 Join the KeystoneJS Slack for discussion with the community & contributors:
  * https://launchpass.com/keystonejs
 -->

## Description of changes


## Related issues (if any)


## Testing

 - [ ] List browser version(s) any admin UI changes were tested in:
 - [ ] Please confirm you've added (or verified) test coverage for this change.
 - [ ] Please confirm `npm run test-all` ran successfully.

<!--
 Notes:
 * For more information on the End-2-End (E2E) testing framework for Keystone 4, see:
    https://github.com/keystonejs/keystone-nightwatch-e2e
 * To successfully have all E2E tests pass you need to have the following set up:
    - A recent version of Chrome or Firefox
    - Java Runtime Environment 1.8+
 * If you are developing in Windows you may run into linebreak linting issues.
   One possible workaround is to remove the "linebreak-style" rule in `node_modules/eslint-config-keystone/eslintrc.json`.
 -->

