### PR TITLE
Update initLetsEncrypt.js

### DIFF
--- a/server/initLetsEncrypt.js
+++ b/server/initLetsEncrypt.js
@@ -37,7 +37,7 @@ module.exports = function (keystone, app) {
 	}
 	// TODO maybe we should use le-store-mongo
 	var lex = letsencrypt.create({
-		version: version;
+		version: version,
 		server: server,
 		approveDomains: approveDomains,
 		agreeTos: agreeTos,

--- a/server/initLetsEncrypt.js
+++ b/server/initLetsEncrypt.js
@@ -22,9 +22,10 @@ module.exports = function (keystone, app) {
 		console.error('To use Let\'s Encrypt you need to have a regular HTTP listener as well. Please set ssl to either `true` or `"force"`.');
 	}
 
+	var version = options.version ? options.version : 'draft-12'
 	var email = options.email;
 	var approveDomains = options.domains;
-	var server = options.production ? 'production' : 'staging';
+	var server = options.production ? 'https://acme-v02.api.letsencrypt.org/directory' : 'https://acme-staging-v02.api.letsencrypt.org/directory';
 	var agreeTos = options.tos;
 
 	if (!Array.isArray(approveDomains)) {
@@ -36,6 +37,7 @@ module.exports = function (keystone, app) {
 	}
 	// TODO maybe we should use le-store-mongo
 	var lex = letsencrypt.create({
+		version: version;
 		server: server,
 		approveDomains: approveDomains,
 		agreeTos: agreeTos,


### PR DESCRIPTION
Reenable SSL since v1 of LetsEncrypt EOL is due june.

## Description of changes
Changes the server to the v2 staging and production servers depending on the options set.

## Related issues (if any)
Unable to generate SSL certificates when on a new server or domain.

## Testing
It's been tested and found it working with these changes, only want to push it so other people using keystone can get it working again.

