### PR TITLE
V4.2.2

### DIFF
--- a/lib/core/openDatabaseConnection.js
+++ b/lib/core/openDatabaseConnection.js
@@ -32,7 +32,6 @@ module.exports = function openDatabaseConnection (callback) {
 				rs_name: replicaData.db.replicaSetOptions.rs_name,
 				readPreference: replicaData.db.replicaSetOptions.readPreference,
 			},
-			useMongoClient: true,
 		};
 
 		debug('connecting to replica set');
@@ -42,7 +41,6 @@ module.exports = function openDatabaseConnection (callback) {
 		debug('connecting to mongo');
 		keystone.initDatabaseConfig();
 		var mongo_options = keystone.get('mongo options') || {};
-		mongo_options.useMongoClient = true;
 		keystone.mongoose.connect(keystone.get('mongo'), mongo_options);
 	}
 

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "method-override": "^3.0.0",
     "mime-types": "^2.1.24",
     "moment": "^2.24.0",
-    "mongoose": "^6.7.3",
+    "mongoose": "^5.13.11",
     "morgan": "^1.9.1",
     "multer": "^1.4.1",
     "numeral": "^2.0.6",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "method-override": "^3.0.0",
     "mime-types": "^2.1.24",
     "moment": "^2.24.0",
-    "mongoose": "^4.13.14",
+    "mongoose": "^6.7.3",
     "morgan": "^1.9.1",
     "multer": "^1.4.1",
     "numeral": "^2.0.6",


### PR DESCRIPTION
Updated to use MongoDB 6

## Testing

 - [ ] List browser version(s) any admin UI changes were tested in:
 - [ ] Please confirm you've added (or verified) test coverage for this change.
 - [ ] Please confirm `npm run test-all` ran successfully.

<!--
 Notes:
 * For more information on the End-2-End (E2E) testing framework for Keystone 4, see:
    https://github.com/keystonejs/keystone-nightwatch-e2e
 * To successfully have all E2E tests pass you need to have the following set up:
    - A recent version of Chrome or Firefox
    - Java Runtime Environment 1.8+
 * If you are developing in Windows you may run into linebreak linting issues.
   One possible workaround is to remove the "linebreak-style" rule in `node_modules/eslint-config-keystone/eslintrc.json`.
 -->

